### PR TITLE
BRS-166: fixing incorrectly disabled cancel button

### DIFF
--- a/src/app/passes/pass-list/pass-table-row/pass-table-row.component.html
+++ b/src/app/passes/pass-list/pass-table-row/pass-table-row.component.html
@@ -34,7 +34,7 @@
             </span>
         </button>
         <button type="button"
-            [disabled]="rowData?.passStatus !== 'active' || cancelLoading"
+            [disabled]="rowData?.passStatus === 'cancelled' || rowData?.passStatus === 'expired' || cancelLoading"
             class="btn btn-outline-danger"
             title="Cancel {{validate('registrationNumber')}}"
             (click)="navigate('cancel')">


### PR DESCRIPTION
### Jira Ticket:
BRS-166

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-166

### Description:
This changes fixes a bug where the cancel button was disabled when trying to cancel passes in any facility. The bug was due to the front checking whether the current status of `passStatus === 'active'`, and disabling the button if this was not true. There is an additional status `'reserved'` that should also not disable the button. Front end logic was altered to reflect this. 