### PR TITLE
BRS-624 make park url in park creation mandatory

### DIFF
--- a/src/app/park-form/park-form.component.html
+++ b/src/app/park-form/park-form.component.html
@@ -93,7 +93,7 @@
 
             <div class="row">
                 <div class="form-group col-12">
-                    <label for="bcParksLink">Link to BC Parks Site</label>
+                    <label for="bcParksLink">Link to BC Parks Site <span class="text-danger">*</span></label>
                     <div class="input-group">
                         <input id="bcParksLink"
                             formControlName="bcParksLink"

--- a/src/app/park-form/park-form.component.ts
+++ b/src/app/park-form/park-form.component.ts
@@ -31,7 +31,7 @@ export class ParkFormComponent implements OnInit, OnDestroy {
     ]),
     status: new FormControl(false),
     visible: new FormControl(false),
-    bcParksLink: new FormControl(''),
+    bcParksLink: new FormControl('', Validators.required),
     mapLink: new FormControl(''),
   });
 


### PR DESCRIPTION
### Jira Ticket:
BRS-624

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-624

### Description:
Making the `bcparks URL` field in the parks creation flow a mandatory field. Leaving this field blank will prevent booking emails from sending properly. If the url is invalid, the emails will still send. 