### PR TITLE
BRS-658 formatting dates as ISO to conform to new TZ changes

### DIFF
--- a/src/app/shared/form-generator/form-generator.component.ts
+++ b/src/app/shared/form-generator/form-generator.component.ts
@@ -70,7 +70,7 @@ export class FormGeneratorComponent implements OnInit {
     Object.keys(this.form.controls).forEach(key => {
       if (this.form.get(key).dirty) {
         if (this.datePickerKeys.includes(key)) {
-          let jsDate = this.utils.convertFormGroupNGBDateToJSDate(this.form.get(key).value);
+          let jsDate = this.utils.convertFormGroupNGBDateToISODate(this.form.get(key).value);
           if (jsDate) {
             paramsObj[key] = jsDate;
           }

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ISearchResults } from 'app/shared/models/search';
+import { DateTime } from 'luxon';
 
 const encode = encodeURIComponent;
 window['encodeURIComponent'] = (component: string) => {
@@ -65,6 +66,35 @@ export class Utils {
     } else {
       return new Date(nGBDate.year, nGBDate.month - 1, nGBDate.day, nGBTime.hour, nGBTime.minute);
     }
+  }
+
+  public convertFormGroupNGBDateToISODate(nGBDate, nGBTime = null) {
+    if (!nGBDate) {
+      return null;
+    }
+
+    let datetime = DateTime.fromObject(
+      {
+        year: nGBDate.year,
+        month: nGBDate.month,
+        day: nGBDate.day,
+        hour: 12
+      },
+      {
+        zone: 'America/Vancouver'
+      }
+    );
+
+    if (nGBTime) {
+      datetime.set(
+        {
+          hour: nGBTime.hour,
+          minute: nGBTime.minute
+        }
+      );
+    }
+
+    return datetime.toISO();
   }
 
   public convert24hTo12hTime(hour: number): { hour: string, amPm: string } {


### PR DESCRIPTION
### Jira Ticket:
BRS-658

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-658

### Description:
This change alters how the admin portal generates the `date` queryParam for `readPass` - since the new `readPass` as of https://github.com/bcgov/parks-reso-api/pull/108 can no longer accept the JS ISO Date long format (`Sat Jun 11 2022 00:00:00 GMT-0700 (Pacific Daylight Time)`, for example).