### PR TITLE
BRS-687: Redirect to login page on authRefreshError

### DIFF
--- a/src/app/services/keycloak.service.ts
+++ b/src/app/services/keycloak.service.ts
@@ -63,6 +63,7 @@ export class KeycloakService {
 
         this.keycloakAuth.onAuthRefreshError = () => {
           // console.log('onAuthRefreshError');
+          window.location.href = 'login';
         };
 
         this.keycloakAuth.onAuthLogout = () => {


### PR DESCRIPTION
### Jira Ticket:
BRS-687

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-687

### Description:
This redirects the user to the login page once an authRefreshError happens in keycloak, typically when the users' session expires.