### PR TITLE
NOBUG - upgrading GH Actions to Node16

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -18,7 +18,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -40,7 +40,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -63,7 +63,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -113,7 +113,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -169,7 +169,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -21,7 +21,7 @@ jobs:
     environment: prod
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -76,7 +76,7 @@ jobs:
     environment: prod
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -21,7 +21,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -76,7 +76,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr-linting.yaml
+++ b/.github/workflows/pr-linting.yaml
@@ -9,7 +9,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
### Jira Ticket:

NOBUG

Upgrading GH actions to run Node16.
https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/