### PR TITLE
NOBUG: capacities saved as integers

### DIFF
--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
@@ -369,7 +369,7 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     for (const day of Object.keys(facilityObj.bookingDays)) {
       if (facilityObj.bookingDays[day]) {
         const weekday =
-          Constants.Weekdays.filter((e) => String(e.id) === day)[0] || null;
+          Constants.Weekdays.filter((weekday) => String(weekday.id) === day)[0] || null;
         bookingDaysList.push(weekday?.name);
       }
     }

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
@@ -228,7 +228,7 @@ export class FacilityEditFormComponent extends BaseFormComponent {
       results.facilityBookingTimes?.capacityAM
     ) {
       resultTimes['AM'] = {
-        max: results.facilityBookingTimes.capacityAM,
+        max: parseInt(results.facilityBookingTimes.capacityAM, 10),
       };
     }
     if (
@@ -236,7 +236,7 @@ export class FacilityEditFormComponent extends BaseFormComponent {
       results.facilityBookingTimes?.capacityPM
     ) {
       resultTimes['PM'] = {
-        max: results.facilityBookingTimes.capacityPM,
+        max: parseInt(results.facilityBookingTimes.capacityPM, 10),
       };
     }
     if (
@@ -244,7 +244,7 @@ export class FacilityEditFormComponent extends BaseFormComponent {
       results.facilityBookingTimes?.capacityDAY
     ) {
       resultTimes['DAY'] = {
-        max: results.facilityBookingTimes.capacityDAY,
+        max: parseInt(results.facilityBookingTimes.capacityDAY, 10),
       };
     }
     // create API submission object
@@ -368,9 +368,8 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     console.log('facilityObj.bookingDays:', facilityObj.bookingDays);
     for (const day of Object.keys(facilityObj.bookingDays)) {
       if (facilityObj.bookingDays[day]) {
-        const weekday = Constants.Weekdays.filter(
-          (e) => String(e.id) === day
-        )[0] || null;
+        const weekday =
+          Constants.Weekdays.filter((e) => String(e.id) === day)[0] || null;
         bookingDaysList.push(weekday?.name);
       }
     }

--- a/src/app/parks-management/modifiers-form/modifiers-form.component.ts
+++ b/src/app/parks-management/modifiers-form/modifiers-form.component.ts
@@ -131,13 +131,13 @@ export class ModifiersFormComponent
   formatFormResults(results) {
     let resultTimes = {};
     if (results.modifierAMChanges) {
-      resultTimes['AM'] = results.modifierAMChanges;
+      resultTimes['AM'] = parseInt(results.modifierAMChanges, 10);
     }
     if (results.modifierPMChanges) {
-      resultTimes['PM'] = results.modifierPMChanges;
+      resultTimes['PM'] = parseInt(results.modifierPMChanges, 10);
     }
     if (results.modifierDAYChanges) {
-      resultTimes['DAY'] = results.modifierDAYChanges;
+      resultTimes['DAY'] = parseInt(results.modifierDAYChanges, 10);
     }
     const postObj = {
       date: results.modifierOverrideDate,


### PR DESCRIPTION
### Jira Ticket:
NOBUG

### Description:
Capacities and modifiers were being saved as strings, which led to string concatenation instead of math logic when comparing numbers. 

Note: This may fix BRS-918.