### PR TITLE
NOBUG: Infinite pass loading

### DIFF
--- a/src/app/parks-management/facility-details/passes-list/passes-list.component.html
+++ b/src/app/parks-management/facility-details/passes-list/passes-list.component.html
@@ -2,6 +2,8 @@
   [tableSchema]="tableSchema"
   [data]="tableRows"
   [emptyTableMsg]="'No passes found.'"
+  [lastEvaluatedKey]="lastEvaluatedKey"
+  (loadMore)="loadMorePasses()"
 ></app-table>
 
 <!-- Here is where we store the templates for the specific modals shown from this page.  -->

--- a/src/app/parks-management/facility-details/passes-list/passes-list.component.ts
+++ b/src/app/parks-management/facility-details/passes-list/passes-list.component.ts
@@ -28,6 +28,7 @@ export class PassesListComponent implements OnInit, OnDestroy {
   public cancelModal: modalSchema;
   public passModalRef: BsModalRef;
   public cancelModalRef: BsModalRef;
+  public lastEvaluatedKey = null;
 
   @ViewChild('passModalTemplate') passModalTemplate: TemplateRef<any>;
   @ViewChild('cancelModalTemplate') cancelModalTemplate: TemplateRef<any>;
@@ -42,6 +43,13 @@ export class PassesListComponent implements OnInit, OnDestroy {
       dataService.watchItem(Constants.dataIds.PASSES_LIST).subscribe((res) => {
         this.tableRows = res;
       })
+    );
+    this.subscriptions.add(
+      dataService
+        .watchItem(Constants.dataIds.PASS_LAST_EVALUATED_KEY)
+        .subscribe((res) => {
+          this.lastEvaluatedKey = res;
+        })
     );
   }
 
@@ -59,6 +67,19 @@ export class PassesListComponent implements OnInit, OnDestroy {
       return true;
     }
     return false;
+  }
+
+  loadMorePasses() {
+    console.log('this.lastEvaluatedKey:', this.lastEvaluatedKey);
+    let loadMoreObj = this.dataService.mergeItemValue(
+      Constants.dataIds.PASS_SEARCH_PARAMS,
+      {
+        ExclusiveStartKeyPK: this.lastEvaluatedKey?.pk?.S,
+        ExclusiveStartKeySK: this.lastEvaluatedKey?.sk?.S,
+        appendResults: true,
+      }
+    );
+    this.passService.fetchData(loadMoreObj);
   }
 
   displayPassModal(passObj) {

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -20,6 +20,30 @@ export class DataService {
     this.data[id].next(value);
   }
 
+  // Append array data to existing dataService id
+  appendItemValue(id, value): any[] {
+    if (!this.checkIfDataExists(id)){
+      this.setItemValue(id, value);
+      return [];
+    } else {
+      const appendObj = this.getItemValue(id).concat(value);
+      this.data[id].next(appendObj);
+      return appendObj;
+    }
+  }
+
+   // Merge object data to existing dataService id
+  mergeItemValue(id, value, attribute = null): any {
+    if (!this.checkIfDataExists(id)){
+      this.setItemValue(id, value);
+      return null;
+    } else {
+      const  assignObj = Object.assign(this.getItemValue(id), value);
+      this.data[id].next(assignObj);
+      return assignObj;
+    }
+  }
+
   public watchItem(id) {
     this.checkIfDataExists(id) ? null : this.initItem(id);
     return this.data[id];

--- a/src/app/services/pass.service.ts
+++ b/src/app/services/pass.service.ts
@@ -29,6 +29,7 @@ export class PassService {
   // passType:,
   // ExclusiveStartKeyPK:,
   // ExclusiveStartKeySK:,
+  // appendResults: boolean,
   // queryParams:
   // }
   async fetchData(params) {
@@ -44,11 +45,18 @@ export class PassService {
       ) {
         dataTag = Constants.dataIds.PASSES_LIST;
         this.loadingService.addToFetchList(dataTag);
-
         const queryParams = this.filterSearchParams(params);
-
         res = await firstValueFrom(this.apiService.get('pass', queryParams));
-        this.dataService.setItemValue(dataTag, res.data);
+        if (params?.appendResults) {
+          this.dataService.appendItemValue(dataTag, res.data)
+        } else {
+          this.dataService.setItemValue(dataTag, res.data);
+        }
+        if (res.LastEvaluatedKey){
+          this.dataService.setItemValue(Constants.dataIds.PASS_LAST_EVALUATED_KEY, res.LastEvaluatedKey)
+        } else {
+          this.dataService.clearItemValue(Constants.dataIds.PASS_LAST_EVALUATED_KEY);
+        }
         this.dataService.setItemValue(
           Constants.dataIds.PASS_SEARCH_PARAMS,
           queryParams

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -11,7 +11,7 @@
         </th>
       </tr>
     </thead>
-    <tbody *ngIf="rows?.length > 0 && !loading">
+    <tbody *ngIf="rows?.length > 0 ">
       <tr
         *ngFor="let row of rows"
         app-table-row
@@ -36,5 +36,12 @@
     <div class="text-muted">
       {{ emptyTableMsg }}
     </div>
+  </div>
+</div>
+<div *ngIf="lastEvaluatedKey && !loading">
+  <div class="d-flex justify-content-center">
+    <button class="btn btn-outline-secondary" (click)="loadMoreClicked()">
+      Load more
+    </button>
   </div>
 </div>

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { LoadingService } from 'src/app/services/loading.service';
 
@@ -28,6 +28,9 @@ export class TableComponent implements OnChanges, OnDestroy {
   @Input() tableSchema: tableSchema;
   @Input() data: any[];
   @Input() emptyTableMsg = 'This table is empty.';
+  @Input() lastEvaluatedKey = null;
+
+  @Output() loadMore: EventEmitter<any> = new EventEmitter();
 
   public columns;
   public rows: any = [];
@@ -70,6 +73,10 @@ export class TableComponent implements OnChanges, OnDestroy {
         this.rows.push(row);
       }
     }
+  }
+
+  loadMoreClicked() {
+    this.loadMore.emit(this.lastEvaluatedKey);
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -6,6 +6,7 @@ export class Constants {
     CURRENT_FACILITY: 'currentFacility',
     PASSES_LIST: 'passesList',
     PASS_SEARCH_PARAMS: 'passSearchParams',
+    PASS_LAST_EVALUATED_KEY: 'passLastEvaluatedKey',
     CANCELLED_PASS: 'cancelledPass',
     RESERVATION_OBJECTS_LIST: 'reservationObjectsList',
     CURRENT_RESERVATIONS_OBJECT: 'currentReservationsObj',


### PR DESCRIPTION
### Jira Ticket:
NOBUG

### Description:
DUP V1 had a 'load more' feature when the number of passes returned by the pass query exceeded DynamoDB's data limit. This change builds in a 'load more' feature to the shared table component and also leverages DynamoDB's `LastEvaluatedKey` functionality. The `dataService` has two new functions: `mergeItemValue` and `appendItemValue`, for adding data to existing `dataService` objects and arrays respectively without overwriting.