### PR TITLE
BRS-936: shortdate-picker should not account for timezone

### DIFF
--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -63,20 +63,30 @@ export class Utils {
     );
   }
 
+  // Converts current epoch time to ISO date in TIMEZONE.
   public getTodaysDate() {
     return DateTime.now().setZone(TIMEZONE).toISO();
   }
 
+  // Converts current epoch time to calendar short date in TIMEZONE.
   public getTodayAsShortDate() {
     return DateTime.now().setZone(TIMEZONE).toISODate();
   }
 
+  // Chops short date from JSDate. Timezones not respected.
+  // Useful if receiving JSDate from a datepicker and we want the calendar date picked irrespective of browser/server tz.
   public convertJSDateToShortDate(date: Date): string {
+    return DateTime.fromJSDate(date).toISODate();
+  }
+
+  // Converts zoned JSDate to zoned short date, respecting any change in timezone.
+  public convertJSDateToZonedShortDate(date: Date): string {
     return DateTime.fromJSDate(date).setZone(TIMEZONE).toISODate();
   }
 
+  // Converts short date to 00:00:00.000 JSDate in TIMEZONE.
   public convertShortDateToJSDate(date: string): Date {
-    return DateTime.fromFormat(date, 'YYYY-MM-DD').setZone(TIMEZONE).toJSDate();
+    return DateTime.fromFormat(date, 'yyyy-LL-dd').setZone(TIMEZONE).toJSDate();
   }
 
   public convertJSDateToNgbTimeStruct(date: Date): NgbTimeStruct {


### PR DESCRIPTION
### Jira Ticket:
BRS-936

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-936

### Description:
Our common form component `shortdate-picker` is applying a timezone offset to calendar dates if the browser is in a timezone other than PT. With `shortdate-picker` we only care about the calendar date. So whatever calendar date is picked in the browser, should be the same date sent to the backend, no TZ conversions necessary.

This change introduces a new function so both cases (timezone respected & timezone not respected) are handled. Also some clarification comments were added to the other datetime utils.