### PR TITLE
NOBUG: hide table data if loading

### DIFF
--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -11,7 +11,7 @@
         </th>
       </tr>
     </thead>
-    <tbody *ngIf="rows?.length > 0 ">
+    <tbody *ngIf="rows?.length > 0 && !loading">
       <tr
         *ngFor="let row of rows"
         app-table-row


### PR DESCRIPTION
### Description:
This change hides table rows if the system is loading data.

This was originally in the code base, but was erroneously removed when infinite loading was introduced so that the user could see existing table data while more was being brought in.

Since table data is typically cached in browser memory, when navigating from one facility to another, the table data of the previous facility persists for a few seconds while the correct data loads. This leads to a poor user experience when there is a slow connection.

In the future, we can look at a more detailed loading service so that we dont have to blanket hide data when any part of the application is loading. 
