### PR TITLE
BRS-941: timepicker resets with rest of form

### DIFF
--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form-details/facility-edit-form-details.component.html
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form-details/facility-edit-form-details.component.html
@@ -30,6 +30,7 @@
         [showSeconds]="false"
         [is24HTime]="false"
         [defaultTime]="{hour: 7, minute: 0, second: 0}"
+        [reset]="resetEvent"
       >
       </app-timepicker>
     </div>

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form-details/facility-edit-form-details.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form-details/facility-edit-form-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -7,6 +7,7 @@ import { UntypedFormControl } from '@angular/forms';
   styleUrls: ['./facility-edit-form-details.component.scss']
 })
 export class FacilityEditFormDetailsComponent implements OnInit {
+  @Input() resetEvent = new EventEmitter();
   @Input() facilityName = new UntypedFormControl();
   @Input() facilityType = new UntypedFormControl();
   @Input() facilityBookingOpeningHour = new UntypedFormControl();

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.html
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.html
@@ -13,6 +13,7 @@
       [facilityType]="fields?.facilityType"
       [facilityBookingOpeningHour]="fields?.facilityBookingOpeningHour"
       [facilityBookingDaysAhead]="fields?.facilityBookingDaysAhead"
+      [resetEvent]="resetEvent"
     >
     </app-facility-edit-form-details>
   </div>
@@ -35,7 +36,7 @@
     </button>
     <button
       class="btn btn-secondary me-2"
-      (click)="setForm()"
+      (click)="onFormReset()"
       [disabled]="form?.pristine"
     >
       Reset

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
@@ -212,6 +212,11 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     }
   }
 
+  onFormReset() {
+    this.setForm();
+    this.resetEvent.emit()
+  }
+
   submitFacilityChanges(facilityObj) {
     if (this.isEditMode.value === true) {
       this.facilityService.putFacility(facilityObj, this.park.sk);
@@ -367,7 +372,6 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     ]);
 
     let bookingDaysList = [];
-    console.log('facilityObj.bookingDays:', facilityObj.bookingDays);
     for (const day of Object.keys(facilityObj.bookingDays)) {
       if (facilityObj.bookingDays[day]) {
         const weekday =

--- a/src/app/shared/components/ds-forms/base-form/base-form.component.ts
+++ b/src/app/shared/components/ds-forms/base-form/base-form.component.ts
@@ -2,6 +2,7 @@ import {
   AfterContentInit,
   ChangeDetectorRef,
   Component,
+  EventEmitter,
   OnDestroy,
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
@@ -34,6 +35,10 @@ export class BaseFormComponent implements OnDestroy, AfterContentInit {
   public loading = false;
   public disabledControls: any = {}; // object of disabled controls
   public isSubmitted = false;
+
+  // Form events that can be listened to:
+  // TODO: add more events if necessary
+  public resetEvent = new EventEmitter();
 
   constructor(
     public bFormBuilder: UntypedFormBuilder,

--- a/src/app/shared/components/ds-forms/timepicker/timepicker.component.spec.ts
+++ b/src/app/shared/components/ds-forms/timepicker/timepicker.component.spec.ts
@@ -8,9 +8,8 @@ describe('TimepickerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TimepickerComponent ]
-    })
-    .compileComponents();
+      declarations: [TimepickerComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TimepickerComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,36 @@ describe('TimepickerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize time properly', () => {
+    expect(component.control.value).toEqual({ hour: 0, minute: 0, second: 0 });
+    component.defaultTime = { hour: 4, minute: 5, second: 6 };
+    component.ngOnInit();
+    expect(component.control.value).toEqual({ hour: 4, minute: 5, second: 6 });
+    component.control.setValue({ hour: 1, minute: 2, second: 3 });
+    component.ngOnInit();
+    expect(component.control.value).toEqual({ hour: 1, minute: 2, second: 3 });
+  });
+
+  it('should update time properly', () => {
+    component.modelTime = new Date('December 9, 2022 11:46:00');
+    component.onTimeChange('event');
+    expect(component.isInitialLoad).toBeFalsy();
+    component.onTimeChange('event');
+    expect(component.control.value).toEqual({
+      hour: 11,
+      minute: 46,
+      second: 0,
+    });
+    component.onTimeChange(null);
+    expect(component.control.value).toEqual({ hour: 0, minute: 0, second: 0 });
+  });
+
+  it('should clear time properly', () => {
+    expect(component.initialTime).toEqual({ hour: 0, minute: 0, second: 0 });
+    component.control.setValue({ hour: 1, minute: 2, second: 3 });
+    component.clearTime();
+    expect(component.control.value).toEqual({ hour: 0, minute: 0, second: 0 });
   });
 });

--- a/src/app/shared/components/ds-forms/timepicker/timepicker.component.ts
+++ b/src/app/shared/components/ds-forms/timepicker/timepicker.component.ts
@@ -28,6 +28,7 @@ export class TimepickerComponent
 
   private subscriptions = new Subscription();
   public initialTime;
+  public isInitialLoad = true;
   public modelTime;
   public utils = new Utils();
 
@@ -35,40 +36,55 @@ export class TimepickerComponent
     this.initialTime = {
       hour: this.control?.value?.hour || this.defaultTime.hour,
       minute: this.control?.value?.minute || this.defaultTime.minute,
-      second: this.control?.value?.second || this.defaultTime.second
-    }
+      second: this.control?.value?.second || this.defaultTime.second,
+    };
     this.setTime(
       this.initialTime.hour,
       this.initialTime.minute,
-      this.initialTime.second,
+      this.initialTime.second
     );
     if (this.reset) {
-      this.subscriptions.add(this.reset.subscribe(() => this.clearDate()));
+      this.subscriptions.add(
+        this.reset.subscribe(() => {
+          this.clearTime();
+        })
+      );
     }
   }
 
   setTime(hour, minute, second): void {
     this.modelTime = new Date();
     this.modelTime.setHours(hour, minute, second);
+    this.control.setValue(
+      this.utils.convertJSDateToNgbTimeStruct(this.modelTime)
+    );
   }
 
   onTimeChange(event) {
+    if (this.isInitialLoad) {
+      this.isInitialLoad = false;
+    } else {
+      this.control.markAsDirty();
+    }
     if (!event || !this.modelTime) {
-      this.setTime(
-        this.initialTime.hour,
-        this.initialTime.minute,
-        this.initialTime.second
-      );
+      this.clearTime();
     }
     this.control.setValue(
       this.utils.convertJSDateToNgbTimeStruct(this.modelTime)
     );
   }
 
-  clearDate() {
-    this.modelTime = null as any;
-    this.control.setValue(null);
-    this.control.markAsDirty();
+  clearTime() {
+    this.setTime(
+      this.initialTime.hour,
+      this.initialTime.minute,
+      this.initialTime.second
+    );
+    this.control.setValue(
+      this.utils.convertJSDateToNgbTimeStruct(this.modelTime)
+    );
+    this.isInitialLoad = true;
+    this.control.markAsPristine();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
### Jira Ticket:
BRS-941

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1941

### Description:
Facility edit form `timepicker` was not resetting with the rest of the form. This is because the bound model for `timepicker` is decoupled from the form control value for the time selected. This is one of the drawbacks from using an external `timepicker` package with our latest form engine. As a workaround, an EventEmitter was added when the form is reset, and the `timepicker` listens to the event. We can expand our form engine to fire other events if necessary in the future. 

Also added test coverage for the timepicker component.