### PR TITLE
BRS-965: api & data service test coverage

### DIFF
--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,4 +1,7 @@
-import { HttpClient, HttpHandler } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { ApiService } from './api.service';
@@ -7,15 +10,151 @@ import { LoggerService } from './logger.service';
 
 describe('ApiService', () => {
   let service: ApiService;
+  let httpTestingController: HttpTestingController;
+
+  let mockConfigService = {
+    config: {
+      API_LOCATION: 'location',
+      API_PATH: '/path',
+      ENVIRONMENT: 'test',
+    },
+  };
+
+  let mockQueryParams = {
+    param1: 'value1',
+    param2: 'value2',
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [HttpClient, HttpHandler, ConfigService, LoggerService],
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: ConfigService, useValue: mockConfigService },
+        LoggerService,
+      ],
     });
     service = TestBed.inject(ApiService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service.init();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+    expect(service.apiPath).toEqual('location/path');
+    expect(service.env).toEqual('test');
+  });
+
+  it('gets the environment', async () => {
+    expect(service.getEnvironment()).toEqual('test');
+  });
+
+  it('generates query string', async () => {
+    expect(service['generateQueryString'](mockQueryParams)).toEqual(
+      'param1=value1&param2=value2'
+    );
+  });
+
+  it('gets', async () => {
+    // no params
+    service.get('getPk').subscribe((res) => {
+      expect(res.params).toBeNull();
+    });
+    const emptyGet = httpTestingController.expectOne(
+      `${service.apiPath}/getPk?`
+    );
+    expect(emptyGet.request.method).toEqual('GET');
+    emptyGet.flush({ params: null });
+    // with params
+    service.get('getPk', mockQueryParams).subscribe((res) => {
+      expect(res.params).toBeDefined();
+      expect(res.params.param1).toEqual(mockQueryParams.param1);
+      expect(res.params.param2).toEqual(mockQueryParams.param2);
+    });
+    let queryString = service['generateQueryString'](mockQueryParams);
+    const paramGet = httpTestingController.expectOne(
+      `${service.apiPath}/getPk?${queryString}`
+    );
+    expect(paramGet.request.method).toEqual('GET');
+    paramGet.flush({ params: mockQueryParams });
+  });
+
+  it('puts', async () => {
+    // no params
+    service.put('putPk', { mockObj: 'mockObj' }).subscribe((res) => {
+      expect(res.param).toBeNull();
+    });
+    const emptyPut = httpTestingController.expectOne(
+      `${service.apiPath}/putPk?`
+    );
+    expect(emptyPut.request.method).toEqual('PUT');
+    emptyPut.flush({ param: null });
+    // with params
+    service
+      .put('putPk', { mockObj: 'mockObj' }, mockQueryParams)
+      .subscribe((res) => {
+        expect(res.params).toBeDefined();
+        expect(res.params.param1).toEqual(mockQueryParams.param1);
+        expect(res.params.param2).toEqual(mockQueryParams.param2);
+      });
+    let queryString = service['generateQueryString'](mockQueryParams);
+    const paramPut = httpTestingController.expectOne(
+      `${service.apiPath}/putPk?${queryString}`
+    );
+    expect(paramPut.request.method).toEqual('PUT');
+    paramPut.flush({ params: mockQueryParams });
+  });
+
+  it('posts', async () => {
+    // no params
+    service.post('postPk', { mockObj: 'mockObj' }).subscribe((res) => {
+      expect(res.param).toBeNull();
+    });
+    const emptyPost = httpTestingController.expectOne(
+      `${service.apiPath}/postPk?`
+    );
+    expect(emptyPost.request.method).toEqual('POST');
+    emptyPost.flush({ param: null });
+    // with params
+    service
+      .post('postPk', { mockObj: 'mockObj' }, mockQueryParams)
+      .subscribe((res) => {
+        expect(res.params).toBeDefined();
+        expect(res.params.param1).toEqual(mockQueryParams.param1);
+        expect(res.params.param2).toEqual(mockQueryParams.param2);
+      });
+    let queryString = service['generateQueryString'](mockQueryParams);
+    const paramPost = httpTestingController.expectOne(
+      `${service.apiPath}/postPk?${queryString}`
+    );
+    expect(paramPost.request.method).toEqual('POST');
+    paramPost.flush({ params: mockQueryParams });
+  });
+
+  it('deletes', async () => {
+    // no params
+    service.delete('deletePk').subscribe((res) => {
+      expect(res.param).toBeNull();
+    });
+    const emptyDelete = httpTestingController.expectOne(
+      `${service.apiPath}/deletePk?`
+    );
+    expect(emptyDelete.request.method).toEqual('DELETE');
+    emptyDelete.flush({ param: null });
+    // with params
+    service.delete('deletePk', mockQueryParams).subscribe((res) => {
+      expect(res.params).toBeDefined();
+      expect(res.params.param1).toEqual(mockQueryParams.param1);
+      expect(res.params.param2).toEqual(mockQueryParams.param2);
+    });
+    let queryString = service['generateQueryString'](mockQueryParams);
+    const paramDelete = httpTestingController.expectOne(
+      `${service.apiPath}/deletePk?${queryString}`
+    );
+    expect(paramDelete.request.method).toEqual('DELETE');
+    paramDelete.flush({ params: mockQueryParams });
   });
 });

--- a/src/app/services/auto-fetch.service.spec.ts
+++ b/src/app/services/auto-fetch.service.spec.ts
@@ -1,0 +1,49 @@
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { AutoFetchService } from './auto-fetch.service';
+import { ConfigService } from './config.service';
+import { LoggerService } from './logger.service';
+
+describe('AutoFetchService', () => {
+  let service: AutoFetchService;
+
+  let mockLoggerService = {
+    debug: (str) => {
+      return 'debug';
+    },
+  };
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        HttpClient,
+        HttpHandler,
+        ConfigService,
+        { provide: LoggerService, useValue: mockLoggerService },
+      ],
+    });
+    service = TestBed.inject(AutoFetchService);
+    service.timeIntevalSeconds = 1;
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+    expect(service.fetchQueue).toBeDefined();
+  });
+
+  it('fetches the queue', async () => {
+    const fetchSpy = spyOn(service, 'runFetches').and.callThrough();
+    const parkSpy = spyOn(service['parkService'], 'fetchData');
+    await service.run();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(parkSpy).toHaveBeenCalledTimes(1);
+    jasmine.clock().tick(1001);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(parkSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/services/data.service.spec.ts
+++ b/src/app/services/data.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { DataService } from './data.service';
+
+describe('DataService', () => {
+  let service: DataService;
+
+  beforeEach(() => {
+    // put mockData inside beforeEach, otherwise mutations persist across tests!
+    const mockData = {
+      mock1: new BehaviorSubject('value1'),
+      mock2: new BehaviorSubject(['value21, value22, value23']),
+      mock3: new BehaviorSubject({ mock31: 'value31' }),
+    };
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DataService);
+    service['data'] = mockData;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+    expect(service.getItemValue('mock1')).toEqual('value1');
+    expect(service.getItemValue('mock2')).toEqual([
+      'value21, value22, value23',
+    ]);
+    expect(service.getItemValue('mock3')).toEqual({ mock31: 'value31' });
+  });
+
+  it('inits and sets new data tag', async () => {
+    service.initItem('mock4');
+    expect(service.getItemValue('mock4')).toEqual(null);
+    service.setItemValue('mock4', 'value4');
+    expect(service.getItemValue('mock4')).toEqual('value4');
+    service.clearItemValue('mock4');
+    expect(service.getItemValue('mock4')).toEqual(null);
+  });
+
+  it('appends data to existing tag', async () => {
+    const createNewSpy = spyOn(service, 'setItemValue').and.callThrough();
+    // create new tag if it doesn't exist already
+    service.appendItemValue('mock5', 'value5');
+    expect(createNewSpy).toHaveBeenCalledTimes(1);
+    expect(service.getItemValue('mock5')).toEqual('value5');
+    // append new value to existing array tag
+    service.appendItemValue('mock2', 'value24');
+    expect(service.getItemValue('mock2')).toEqual([
+      'value21, value22, value23',
+      'value24',
+    ]);
+  });
+
+  it('merges data with existing data', async () => {
+    const createNewSpy = spyOn(service, 'setItemValue').and.callThrough();
+    // create new tag if it doesn't exist already
+    service.mergeItemValue('mock6', 'value6');
+    expect(createNewSpy).toHaveBeenCalledTimes(1);
+    expect(service.getItemValue('mock6')).toEqual('value6');
+    // merge new value with existing object tag
+    service.mergeItemValue('mock3', { mock32: 'value32' });
+    expect(service.getItemValue('mock3')).toEqual({
+      mock31: 'value31',
+      mock32: 'value32',
+    });
+  });
+
+  it('provides a subscription point for watching data', async () => {
+    expect(service.watchItem('mock1').value).toEqual('value1');
+  });
+});

--- a/src/app/services/event.service.spec.ts
+++ b/src/app/services/event.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { EventKeywords, EventObject, EventService } from './event.service';
+
+describe('EventService', () => {
+  let service: EventService;
+
+  let mockErrorEvent = new EventObject(
+    EventKeywords.ERROR,
+    'Mock error event occurred',
+    'Event Service'
+  );
+
+  let mockInfoEvent = new EventObject(
+    EventKeywords.INFO,
+    'Mock info event occurred',
+    'Event Service'
+  );
+
+  let mockDebugEvent = new EventObject(
+    EventKeywords.DEBUG,
+    'Mock debug event occurred',
+    'Event Service'
+  );
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [],
+    });
+    service = TestBed.inject(EventService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('handles error events', async () => {
+    service.setError(mockErrorEvent);
+    expect(service['errorEvent'].value).toEqual(mockErrorEvent);
+    service.getError().subscribe((res) => {
+      expect(res).toEqual(mockErrorEvent);
+    });
+  });
+
+  it('handles info events', async () => {
+    service.setInfo(mockInfoEvent);
+    expect(service['infoEvent'].value).toEqual(mockInfoEvent);
+    service.getInfo().subscribe((res) => {
+      expect(res).toEqual(mockInfoEvent);
+    });
+  });
+
+  it('handles debug events', async () => {
+    service.setDebug(mockDebugEvent);
+    expect(service['debugEvent'].value).toEqual(mockDebugEvent);
+    service.getDebug().subscribe((res) => {
+      expect(res).toEqual(mockDebugEvent);
+    });
+  });
+});


### PR DESCRIPTION
### Jira Ticket:
BRS-965

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-965

### Description:
Starting on DUP admin service coverage. Includes `api.service`, `auto-fetch.service`, `data.service`, and `event.service`. Total coverage at 66.6%.