### PR TITLE
BRS-1028: Switching to localStorage, as sessionStorage does not play …

### DIFF
--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -7,7 +7,7 @@ import { KeycloakService } from '../services/keycloak.service';
 
 import { AuthGuard } from './auth.guard';
 
-describe('AuthGuard', () => {
+fdescribe('AuthGuard', () => {
   const mockKeycloakService = jasmine.createSpyObj('KeycloakService', [
     'isAuthenticated',
     'isAuthorized',
@@ -50,13 +50,13 @@ describe('AuthGuard', () => {
     expect(result).toEqual(undefined);
   });
 
-  it('should return redirect to login page if the user is not authenticated and sessionStorage does not contain an idp value', () => {
+  it('should return redirect to login page if the user is not authenticated and localStorage does not contain an idp value', () => {
     const routerMock = TestBed.get(Router);
     routerMock.parseUrl.calls.reset();
 
     mockKeycloakService.isAuthenticated.and.returnValue(false);
 
-    spyOn(window.sessionStorage, 'getItem').and.callFake(() => {
+    spyOn(window.localStorage, 'getItem').and.callFake(() => {
       return null;
     });
 
@@ -66,13 +66,13 @@ describe('AuthGuard', () => {
     expect(routerMock.parseUrl).toHaveBeenCalledWith('/login');
   });
 
-  it('should return redirect to login page if the user is not authenticated and sessionStorage contains an idp value', () => {
+  it('should return redirect to login page if the user is not authenticated and localStorage contains an idp value', () => {
     const routerMock = TestBed.get(Router);
     routerMock.parseUrl.calls.reset();
 
     mockKeycloakService.isAuthenticated.and.returnValue(false);
 
-    spyOn(window.sessionStorage, 'getItem').and.callFake(() => {
+    spyOn(window.localStorage, 'getItem').and.callFake(() => {
       return 'idir';
     });
 

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -23,25 +23,23 @@ export class AuthGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): boolean | UrlTree {
-    // When a successful login occurs, we store the identity provider used in sessionStorage.
-    const lastIdp = sessionStorage.getItem(
+    // When a successful login occurs, we store the identity provider used in localStorage.
+    const lastIdp = localStorage.getItem(
       this.keycloakService.LAST_IDP_AUTHENTICATED
     );
 
     // Not authenticated
     if (!this.keycloakService.isAuthenticated()) {
+      // remove the localStorage value first, so if this authentication attempt
+      // fails then the user will get the login page next time.
+      localStorage.removeItem(this.keycloakService.LAST_IDP_AUTHENTICATED);
+
       if (lastIdp === null) {
         // If an identity provider hasn't been selected then show the login page.
         return this.router.parseUrl('/login');
       }
       // If an identity provider was already selected and successfully authenticated
       // then do a keycloak login with that identity provider.
-
-      // remove the sessionStorage value first, so if this authentication attempt
-      // fails then the user will get the login page next time.
-      sessionStorage.removeItem(this.keycloakService.LAST_IDP_AUTHENTICATED);
-
-      // log in using the last identity provider that worked
       this.keycloakService.login(lastIdp);
       return false;
     }
@@ -54,7 +52,7 @@ export class AuthGuard implements CanActivate {
       // is authenticated already.
       const idp = this.keycloakService.getIdpFromToken();
       if (idp !== '') {
-        sessionStorage.setItem(
+        localStorage.setItem(
           this.keycloakService.LAST_IDP_AUTHENTICATED,
           idp
         );

--- a/src/app/services/keycloak.service.ts
+++ b/src/app/services/keycloak.service.ts
@@ -274,7 +274,7 @@ export class KeycloakService {
     }
 
     // bceid users will have a bceid_userid property
-    if (jwt.bceid_userid !== undefined) {
+    if (jwt.bceid_userid !== undefined || jwt.bceid_username !== undefined) {
       return this.idpHintEnum.BCEID;
     }
 


### PR DESCRIPTION
…nice when you open the same auth'd URL in a new tab, or on a mobile device when scanning a QR code  is not an option so the new browser tab doesn't import the session storage from the other tab forcing you to log in again.

### Jira Ticket:
BRS-1028

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1028

### Description:
For testing, you will need to check your `idir_userid` is set in KC dev/test (some profiles do not have them).  Sign-in normally, pick whatever IDP you want to log in as, and then get to the homepage. Then open a new tab and copy/paste the url. It should not ask you for a login.