### PR TITLE
BRS-1032 basic metrics card stubout

### DIFF
--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -7,7 +7,7 @@ import { KeycloakService } from '../services/keycloak.service';
 
 import { AuthGuard } from './auth.guard';
 
-fdescribe('AuthGuard', () => {
+describe('AuthGuard', () => {
   const mockKeycloakService = jasmine.createSpyObj('KeycloakService', [
     'isAuthenticated',
     'isAuthorized',

--- a/src/app/services/auto-fetch.service.spec.ts
+++ b/src/app/services/auto-fetch.service.spec.ts
@@ -24,10 +24,14 @@ describe('AutoFetchService', () => {
     });
     service = TestBed.inject(AutoFetchService);
     service.timeIntevalSeconds = 1;
+    // https://github.com/gruntjs/grunt-contrib-jasmine/issues/213
+    // Receiving error unless uninstall/install are both in beforeEach
+    // likely due to async nature of tests
+    jasmine.clock().uninstall();
     jasmine.clock().install();
   });
 
-  afterEach(() => {
+  afterAll(() => {
     jasmine.clock().uninstall();
   });
 

--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.html
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.html
@@ -1,0 +1,11 @@
+<div class="card">
+  <div class="card-body">
+    <h4>{{label}}</h4>
+    <div *ngIf="animate">
+      <h1 class="mb-0" [countTo]="_value" [duration]="animationDuration" [jitter]="animationJitter"></h1>
+    </div>
+    <div *ngIf="!animate">
+      <h1 class="mb-0">{{ (_value | number:'1.0-0':'en-US') || '-' }}</h1>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.spec.ts
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { BasicMetricComponent } from './basic-metric.component';
+
+describe('BasicMetricComponent', () => {
+  let component: BasicMetricComponent;
+  let fixture: ComponentFixture<BasicMetricComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BasicMetricComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(BasicMetricComponent);
+    component = fixture.componentInstance;
+    component._value = 2000;
+    component.label = 'Test Label';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the metric card properly', async () => {
+    const cardElement = fixture.debugElement.query(By.css('.card-body')).nativeElement;
+    const level = cardElement.getElementsByTagName('h4')[0];
+    expect(level.innerText).toContain('Test Label');
+    const value = cardElement.getElementsByTagName('h1')[0];
+    expect(value.innerText).toContain('2,000');
+    component._value = 2500;
+    fixture.detectChanges();
+    expect(value.innerText).toContain('2,500');
+  });
+});

--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.ts
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-basic-metric',
+  templateUrl: './basic-metric.component.html',
+  styleUrls: ['./basic-metric.component.scss'],
+})
+export class BasicMetricComponent {
+  @Input() label: string; // metric label
+  @Input() set value(value: number) {
+    this._value = value;
+  }
+  // optional
+  @Input() animate: boolean = false; // animates changes in the metric if true
+  @Input() animationDuration: number = 1500; // duration of metric animation
+  @Input() animationJitter: boolean = false; // applies jitter to animations to create asynchronous effect
+
+  public _value: number = NaN;
+}

--- a/src/app/shared/components/metrics/shared-metrics.module.ts
+++ b/src/app/shared/components/metrics/shared-metrics.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BasicMetricComponent } from './basic-metric/basic-metric.component';
+import { CountToDirective } from '../../utils/count-to.directive';
+
+@NgModule({
+  declarations: [BasicMetricComponent, CountToDirective],
+  imports: [CommonModule],
+  exports: [BasicMetricComponent],
+})
+export class SharedMetricsModule {}

--- a/src/app/shared/utils/count-to.directive.spec.ts
+++ b/src/app/shared/utils/count-to.directive.spec.ts
@@ -1,0 +1,46 @@
+import { ElementRef, Renderer2 } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { CountToDirective } from './count-to.directive';
+
+describe('CountToDirective', () => {
+  let directive;
+  const elementRef = new ElementRef('p');
+  let renderer: Renderer2;
+
+  beforeEach(async () => {
+    directive = new CountToDirective(elementRef, renderer);
+  });
+
+  it('should create an instance', () => {
+    const elementRef = new ElementRef('p');
+    let renderer: Renderer2;
+    const directive = new CountToDirective(elementRef, renderer);
+    expect(directive).toBeTruthy();
+  });
+
+  it('calulates quartic ease function properly', async () => {
+    let res = directive.easeOutQuart(3);
+    expect(res).toEqual(-15);
+  });
+
+  it('calls display functions', () => {
+    const displaySpy = spyOn(directive, 'displayCurrentCount');
+    directive.count = 2500;
+    expect(directive._count.value).toBe(2500);
+    directive.count = 3000;
+    expect(directive._count.value).toBe(3000);
+    expect(directive._oldCount.value).toBe(2500);
+    directive.jitter = true;
+    expect(directive._jitter.value).toBeTrue();
+    directive.duration = 1500;
+    expect(directive._duration.value).toBe(1500);
+    directive.ngOnInit();
+    expect(displaySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys', () => {
+    const unsubscribeSpy = spyOn(directive.ngUnsubscribe, 'complete');
+    directive.ngOnDestroy();
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/shared/utils/count-to.directive.ts
+++ b/src/app/shared/utils/count-to.directive.ts
@@ -1,0 +1,106 @@
+import { formatNumber } from '@angular/common';
+import {
+  Directive,
+  ElementRef,
+  Input,
+  OnDestroy,
+  Renderer2,
+} from '@angular/core';
+import {
+  animationFrameScheduler,
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  endWith,
+  interval,
+  map,
+  Subject,
+  switchMap,
+  takeUntil,
+  takeWhile,
+} from 'rxjs';
+
+@Directive({
+  selector: '[countTo]',
+})
+export class CountToDirective implements OnDestroy {
+  @Input('countTo') set count(count: number) {
+    this._oldCount.next(this._count.value);
+    this._count.next(count);
+  }
+  @Input() set duration(duration: number) {
+    this._duration.next(duration);
+  }
+  @Input() set jitter(jitter: boolean) {
+    this._jitter.next(jitter);
+  }
+
+  private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+  // default count
+  private readonly _count = new BehaviorSubject(0);
+  private readonly _oldCount = new BehaviorSubject(0);
+  // default duration
+  private readonly _duration = new BehaviorSubject(1000);
+  // default jitter (countUp takes up to 20% longer for randomized effect)
+  private readonly _jitter = new BehaviorSubject(false);
+
+  private readonly _currentValue = combineLatest([
+    this._count,
+    this._duration,
+    this._oldCount,
+  ]).pipe(
+    switchMap(([count, animationDuration, oldCount]) => {
+      // get distance between number change
+      const distance = count - oldCount;
+      // stagger finish time
+      if (this._jitter.value) {
+        animationDuration = Math.floor(
+          animationDuration * (1 + Math.random() / 5)
+        );
+      }
+      const frameDuration = 1000 / 60;
+      const totalFrames = Math.round(animationDuration / frameDuration);
+      return interval(frameDuration, animationFrameScheduler).pipe(
+        map((currentFrame) => currentFrame / totalFrames),
+        takeWhile((progress) => progress <= 1),
+        map((progress) => this.easeOutQuart(progress)),
+        map((progress) => oldCount + Math.round(progress * distance)),
+        endWith(count),
+        distinctUntilChanged()
+      );
+    })
+  );
+
+  constructor(
+    private readonly elementRef: ElementRef,
+    private readonly renderer: Renderer2
+  ) {}
+
+  ngOnInit(): void {
+    this.displayCurrentCount();
+  }
+
+  // Quartic ease out function
+  easeOutQuart(x: number): number {
+    return 1 - Math.pow(1 - x, 4);
+  }
+  
+  private displayCurrentCount(): void {
+    this._currentValue
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((currentValue) => {
+        const displayValue = currentValue
+          ? formatNumber(currentValue, 'en-US')
+          : '-';
+        this.renderer.setProperty(
+          this.elementRef.nativeElement,
+          'innerHTML',
+          displayValue
+        );
+      });
+  }
+
+  ngOnDestroy(): void {
+      this.ngUnsubscribe.complete();
+  }
+}

--- a/src/app/shared/utils/count-to.directive.ts
+++ b/src/app/shared/utils/count-to.directive.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   Input,
   OnDestroy,
+  OnInit,
   Renderer2,
 } from '@angular/core';
 import {
@@ -21,9 +22,10 @@ import {
 } from 'rxjs';
 
 @Directive({
+    // eslint-disable-next-line
   selector: '[countTo]',
 })
-export class CountToDirective implements OnDestroy {
+export class CountToDirective implements OnDestroy, OnInit {
   @Input('countTo') set count(count: number) {
     this._oldCount.next(this._count.value);
     this._count.next(count);

--- a/src/app/shared/utils/utils.spec.ts
+++ b/src/app/shared/utils/utils.spec.ts
@@ -55,8 +55,8 @@ describe('Utils', () => {
     // we cannot test any tz-respecting functions as we cannot guarantee which tz
     // these tests will run in.
     let date = new Date();
-    date.setDate(31);
     date.setMonth(11);
+    date.setDate(31);
     date.setFullYear(2014);
     // convertJSDateToNGBDate
     let NGBDate = utils.convertJSDateToNGBDate(date);


### PR DESCRIPTION
### Jira Ticket:
BRS-1032

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1032

### Description:
This change adds a basic metrics card component that can be called to render a basic numerical metric. This can be done in inline HTML by the following:

```
basic:
 <app-basic-metric [label]="'Metric Label'" [value]="numericVariable"></app-basic-metric>

with ticker animation:
 <app-basic-metric [label]="'Metric Label'" [value]="numericVariable" [animate]="true"></app-basic-metric>
```

You can control the ticker animation with the following directives:
`[animationDuration]="1500"` set ticker animation duration (1.5s by default)
`[animationJitter]="true"` apply duration jitter to animations (animations take up to 20% longer to eliminate the appearance of synchronization between multiple metrics cards).

A handful of UT bugs were also fixed. 