### PR TITLE
BRS-300-1: decouple metrics cards from their contents

### DIFF
--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.html
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.html
@@ -1,11 +1,13 @@
-<div class="card">
-  <div class="card-body">
-    <h4>{{label}}</h4>
-    <div *ngIf="animate">
-      <h1 class="mb-0" [countTo]="_value" [duration]="animationDuration" [jitter]="animationJitter"></h1>
-    </div>
-    <div *ngIf="!animate">
-      <h1 class="mb-0">{{ (_value | number:'1.0-0':'en-US') || '-' }}</h1>
-    </div>
+<div>
+  <div *ngIf="animate">
+    <h1
+      class="mb-0"
+      [countTo]="_value"
+      [duration]="animationDuration"
+      [jitter]="animationJitter"
+    ></h1>
+  </div>
+  <div *ngIf="!animate">
+    <h1 class="mb-0">{{ (_value | number : "1.0-0" : "en-US") || "-" }}</h1>
   </div>
 </div>

--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.spec.ts
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.spec.ts
@@ -14,7 +14,6 @@ describe('BasicMetricComponent', () => {
     fixture = TestBed.createComponent(BasicMetricComponent);
     component = fixture.componentInstance;
     component._value = 2000;
-    component.label = 'Test Label';
     fixture.detectChanges();
   });
 
@@ -22,11 +21,8 @@ describe('BasicMetricComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the metric card properly', async () => {
-    const cardElement = fixture.debugElement.query(By.css('.card-body')).nativeElement;
-    const level = cardElement.getElementsByTagName('h4')[0];
-    expect(level.innerText).toContain('Test Label');
-    const value = cardElement.getElementsByTagName('h1')[0];
+  it('should display the metric properly', async () => {
+    const value = fixture.debugElement.nativeElement.getElementsByTagName('h1')[0];
     expect(value.innerText).toContain('2,000');
     component._value = 2500;
     fixture.detectChanges();

--- a/src/app/shared/components/metrics/basic-metric/basic-metric.component.ts
+++ b/src/app/shared/components/metrics/basic-metric/basic-metric.component.ts
@@ -6,7 +6,6 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./basic-metric.component.scss'],
 })
 export class BasicMetricComponent {
-  @Input() label: string; // metric label
   @Input() set value(value: number) {
     this._value = value;
   }

--- a/src/app/shared/components/metrics/chart-metric/chart-metric.component.html
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric.component.html
@@ -1,6 +1,1 @@
-<div class="card">
-  <div class="card-body">
-    <h4>{{ title }}</h4>
-    <canvas #chartId attr.aria-label="{{ type }}-chart: {{ title }}"></canvas>
-  </div>
-</div>
+<canvas #chartId attr.aria-label="{{ type }}-chart"></canvas>

--- a/src/app/shared/components/metrics/chart-metric/chart-metric.component.spec.ts
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric.component.spec.ts
@@ -34,7 +34,6 @@ describe('ChartMetricComponent', () => {
 
   it('awaits all async calls before building chart', async () => {
     expect(buildSpy).not.toHaveBeenCalled();
-    component.title = 'chart title';
     component.type = 'bar';
     component['_labels'].next(['label1', 'label2']);
     component['_datasets'].next([

--- a/src/app/shared/components/metrics/chart-metric/chart-metric.component.ts
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric.component.ts
@@ -15,7 +15,6 @@ import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
   styleUrls: ['./chart-metric.component.scss'],
 })
 export class ChartMetricComponent implements OnDestroy, AfterViewInit {
-  @Input() title: string = '';
   @Input() type: keyof ChartTypeRegistry; // bar, bubble, doughnut, pie, line, polarArea, radar, scatter
   @Input() set labels(labels: string[]) {
     this._labels.next(labels);

--- a/src/app/shared/components/metrics/metric-card/metric-card.component.html
+++ b/src/app/shared/components/metrics/metric-card/metric-card.component.html
@@ -1,0 +1,6 @@
+<div class="card">
+  <div class="card-body">
+    <h4>{{ title }}</h4>
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/src/app/shared/components/metrics/metric-card/metric-card.component.spec.ts
+++ b/src/app/shared/components/metrics/metric-card/metric-card.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MetricCardComponent } from './metric-card.component';
+
+describe('MetricCardComponent', () => {
+  let component: MetricCardComponent;
+  let fixture: ComponentFixture<MetricCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MetricCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MetricCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    component.title = 'title';
+    fixture.detectChanges();
+    const card =
+      fixture.debugElement.nativeElement.getElementsByTagName('h4')[0];
+    expect(card.innerText).toBe('title');
+  });
+});

--- a/src/app/shared/components/metrics/metric-card/metric-card.component.ts
+++ b/src/app/shared/components/metrics/metric-card/metric-card.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-metric-card',
+  templateUrl: './metric-card.component.html',
+  styleUrls: ['./metric-card.component.scss']
+})
+export class MetricCardComponent {
+  @Input() title: string
+}

--- a/src/app/shared/components/metrics/shared-metrics.module.ts
+++ b/src/app/shared/components/metrics/shared-metrics.module.ts
@@ -4,12 +4,18 @@ import { BasicMetricComponent } from './basic-metric/basic-metric.component';
 import { CountToDirective } from '../../utils/count-to.directive';
 import { ChartMetricComponent } from './chart-metric/chart-metric.component';
 import { registerGlobalChartPlugins } from './chart-metric/chart-metric-plugins';
+import { MetricCardComponent } from './metric-card/metric-card.component';
 
 registerGlobalChartPlugins();
 
 @NgModule({
-  declarations: [BasicMetricComponent, CountToDirective, ChartMetricComponent],
+  declarations: [
+    BasicMetricComponent,
+    CountToDirective,
+    ChartMetricComponent,
+    MetricCardComponent,
+  ],
   imports: [CommonModule],
-  exports: [BasicMetricComponent, ChartMetricComponent],
+  exports: [BasicMetricComponent, ChartMetricComponent, MetricCardComponent],
 })
 export class SharedMetricsModule {}


### PR DESCRIPTION
### Jira Ticket:
BRS-300

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-300

### Description:
Existing metrics components build as part of BRS-300 (BRS-1032, -1033, -1034 etc) were built with the metrics card border and title build individually into each component. This change breaks out the card so it can be reused across all metrics components, and the metrics contents are nested within using `<ng-content>`