### PR TITLE
BRS-1020: New Metrics FE changes

### DIFF
--- a/src/app/metrics/metrics-filter/metrics-filter.component.html
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.html
@@ -5,7 +5,7 @@
     <div class="col">
       <div class="d-flex flex-column flex-md-row justify-content-end">
         <app-shortdate-picker class="p-0 me-md-2 mb-2 mb-md-0" [range]="true" [control]="fields.dateRange"
-          [id]="'dateRange'" [maxDateRange]="366" [icon]="'bi-calendar'">
+          [id]="'dateRange'" [maxDateRange]="366" [icon]="'bi-calendar'" (click)="unsetRange()">
         </app-shortdate-picker>
 
         <!-- medium screen or greater  -->

--- a/src/app/metrics/metrics-filter/metrics-filter.component.html
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.html
@@ -1,49 +1,24 @@
 <form [formGroup]="form">
   <div class="row d-flex justify-content-between mb-4">
-    <app-radio-buttons
-      class="col-md-3 col-sm-12 mb-2 mb-md-0"
-      [control]="fields?.timeSpan"
-      [options]="timeSpanOptions"
-      [optionsLabels]="timeSpanLabels"
-      [group]="false"
-      [id]="'timeSpan'"
-    ></app-radio-buttons>
+    <app-radio-buttons class="col-md-3 col-sm-12 mb-2 mb-md-0" [control]="fields?.timeSpan" [options]="timeSpanOptions"
+      [optionsLabels]="timeSpanLabels" [group]="false" [id]="'timeSpan'"
+      (inputChange)="presetRange($event)"></app-radio-buttons>
     <div class="col">
       <div class="d-flex flex-column flex-md-row justify-content-end">
-        <app-shortdate-picker class="p-0 me-md-2 mb-2 mb-md-0" [range]="true">
+        <app-shortdate-picker class="p-0 me-md-2 mb-2 mb-md-0" [range]="true" [control]="fields.dateRange"
+          [id]="'dateRange'" [maxDateRange]="366">
         </app-shortdate-picker>
 
         <!-- medium screen or greater  -->
         <div class="d-none d-md-flex">
           <div class="dropdown">
-            <button
-              class="btn btn-outline-primary dropdown-toggle me-2"
-              type="button"
-              id="filtersDropdown"
-              data-bs-toggle="dropdown"
-              data-bs-auto-close="outside"
-              aria-expanded="false"
-            >
+            <button class="btn btn-outline-primary dropdown-toggle me-2" type="button" id="filtersDropdown"
+              data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
               <i class="bi bi-list"></i>
               Open Filters
             </button>
             <div class="dropdown-menu" aria-labelledby="filtersDropdown">
-              <ng-container *ngTemplateOutlet="openFilters"></ng-container>
-            </div>
-          </div>
-          <div class="dropdown">
-            <button
-              class="btn btn-primary dropdown-toggle me-2"
-              type="button"
-              id="chartDownloadsDropdown"
-              data-bs-toggle="dropdown"
-              data-bs-auto-close="outside"
-              aria-expanded="false"
-            >
-              Download Charts
-            </button>
-            <div class="dropdown-menu" aria-labelledby="chartDownloadsDropdown">
-              <ng-container *ngTemplateOutlet="downloadCharts"></ng-container>
+              <ng-container *ngTemplateOutlet="parkFacilitySelect"></ng-container>
             </div>
           </div>
         </div>
@@ -53,203 +28,49 @@
           <div class="accordion" id="filterAccordion">
             <div class="accordion-item">
               <div class="d-flex flex-row">
-                <button
-                  class="col btn btn-outline-primary my-1"
-                  data-bs-toggle="collapse"
-                  data-bs-target="#openFilterAccordionContent"
-                  aria-expanded="false"
-                  aria-controls="openFilterAccordionToggle"
-                >
+                <button class="col btn btn-outline-primary my-1" data-bs-toggle="collapse"
+                  data-bs-target="#openFilterAccordionContent" aria-expanded="false"
+                  aria-controls="openFilterAccordionToggle">
                   <i class="bi bi-list"></i>
                   Open Filters
                 </button>
               </div>
               <div class="d-flex flex-row">
-                <div
-                  class="col mb-2 accordion-card accordion-collapse collapse"
-                  id="openFilterAccordionContent"
-                  data-bs-parent="#filterAccordion"
-                >
-                  <ng-container *ngTemplateOutlet="openFilters"></ng-container>
+                <div class="col mb-2 accordion-card accordion-collapse collapse" id="openFilterAccordionContent"
+                  data-bs-parent="#filterAccordion">
+                  <ng-container *ngTemplateOutlet="parkFacilitySelect"></ng-container>
                 </div>
               </div>
             </div>
             <div class="accordion-item">
               <div class="d-flex flex-row">
-                <button
-                  class="col btn btn-block btn-primary my-1"
-                  data-bs-toggle="collapse"
-                  data-bs-target="#downloadChartsAccordionContent"
-                  aria-expanded="false"
-                  aria-controls="openFilterAccordionToggle"
-                >
+                <button class="col btn btn-block btn-primary my-1" data-bs-toggle="collapse"
+                  data-bs-target="#downloadChartsAccordionContent" aria-expanded="false"
+                  aria-controls="openFilterAccordionToggle">
                   Download Charts
                 </button>
-              </div>
-              <div class="d-flex flex-row">
-                <div
-                  class="col mb-1 accordion-card accordion-collapse collapse"
-                  id="downloadChartsAccordionContent"
-                  data-bs-parent="#filterAccordion"
-                >
-                  <ng-container
-                    *ngTemplateOutlet="downloadCharts"
-                  ></ng-container>
-                </div>
               </div>
             </div>
           </div>
         </div>
-
-        <button class="mt-1 mt-md-0 mb-2 mb-md-0 btn btn-primary">
-          Export .csv
-        </button>
       </div>
     </div>
   </div>
 </form>
 
 <ng-template #parkFacilitySelect>
-  <div class="col">
-    <app-picklist
-      [label]="'Park'"
-      [selectOptions]="parkOptions"
-      [control]="fields.park"
-      [id]="'downloadChartsPark'"
-      (inputChange)="parkChange($event)"
-    >
-    </app-picklist>
-  </div>
-  <div class="col">
-    <app-picklist
-      [label]="'Facility'"
-      [selectOptions]="facilityOptions"
-      [placeholder]="'All Facilities'"
-      [control]="fields.facility"
-      [id]="'downloadChartsFacility'"
-    >
-    </app-picklist>
-  </div>
-</ng-template>
-
-<ng-template #openFilters>
   <div class="m-4">
-    <div class="row">
-      <ng-container *ngTemplateOutlet="parkFacilitySelect"></ng-container>
-    </div>
-    <div class="d-flex flex-row-reverse">
-      <button class="btn btn-primary"><div class="px-4">Apply</div></button>
-    </div>
-  </div>
-</ng-template>
-
-<ng-template #downloadCharts>
-  <div class="m-4">
-    <div class="row">
-      <ng-container *ngTemplateOutlet="parkFacilitySelect"></ng-container>
-    </div>
     <div class="row">
       <div class="col">
-        <app-picklist
-          [label]="'File Type'"
-          [selectOptions]="fileTypeOptions"
-          [control]="fields.fileType"
-          [id]="'downloadChartsFileType'"
-          (inputChange)="parkChange($event)"
-        >
+        <app-picklist [label]="'Park'" [selectOptions]="parkOptions" [control]="fields.park" [id]="'downloadChartsPark'"
+          (inputChange)="parkChange($event)">
         </app-picklist>
       </div>
       <div class="col">
-        <!-- dummy column -->
+        <app-picklist [label]="'Facility'" [selectOptions]="facilityOptions" [placeholder]="'All Facilities'"
+          [control]="fields.facility" [id]="'downloadChartsFacility'" (inputChange)="facilityChange($event)">
+        </app-picklist>
       </div>
-    </div>
-    <h4>Charts to Export</h4>
-    <div class="row">
-      <div class="col">
-        <app-checkbox
-          [label]="'Pass breakdown by status'"
-          [control]="fields.exportPassBreakdownByStatus"
-          [id]="'downloadChartsExportPassBreakdownByStatus'"
-          class="d-flex flex-row-reverse justify-content-end"
-        ></app-checkbox>
-      </div>
-      <div class="col">
-        <app-checkbox
-          [label]="'Pass activity by day'"
-          [control]="fields.exportPassActivityByDay"
-          [id]="'downloadChartsExportPassActivityByDay'"
-          class="d-flex flex-row-reverse justify-content-end"
-        ></app-checkbox>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col">
-        <app-checkbox
-          [label]="'Pass trends by hour'"
-          [control]="fields.exportPassTrendsByHour"
-          [id]="'downloadChartsExportPassTrendsByHour'"
-          class="d-flex flex-row-reverse justify-content-end"
-        ></app-checkbox>
-      </div>
-      <div class="col">
-        <app-checkbox
-          [label]="'Busiest days'"
-          [control]="fields.exportBusiestDays"
-          [id]="'downloadChartsExportBusiestDays'"
-          class="d-flex flex-row-reverse justify-content-end"
-        ></app-checkbox>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col">
-        <app-checkbox
-          [label]="'Returning guests'"
-          [control]="fields.exportReturningGuests"
-          [id]="'downloadChartsExportReturningGuests'"
-          class="d-flex flex-row-reverse justify-content-end"
-        ></app-checkbox>
-      </div>
-      <div class="col">
-        <!-- dummy column -->
-      </div>
-    </div>
-    <div class="d-flex justify-content-end">
-      <button
-        class="btn btn-outline-primary me-2"
-        *ngIf="
-          fields?.exportBusiestDays.value !== true ||
-          fields?.exportPassActivityByDay.value !== true ||
-          fields?.exportPassBreakdownByStatus.value !== true ||
-          fields?.exportPassTrendsByHour.value !== true ||
-          fields?.exportReturningGuests.value !== true
-        "
-        (click)="selectAllExports(true)"
-      >
-        <div class="px-4">Select All</div>
-      </button>
-      <button
-        class="btn btn-outline-primary me-2"
-        *ngIf="
-          fields?.exportBusiestDays.value === true &&
-          fields?.exportPassActivityByDay.value === true &&
-          fields?.exportPassBreakdownByStatus.value === true &&
-          fields?.exportPassTrendsByHour.value === true &&
-          fields?.exportReturningGuests.value === true
-        "
-        (click)="selectAllExports(false)"
-      >
-        <div class="px-4">Deselect All</div>
-      </button>
-      <button
-        class="btn btn-primary"
-        [disabled]="
-          !fields?.park?.value ||
-          !fields?.facility?.value ||
-          !fields?.fileType?.value
-        "
-      >
-        <div class="px-4">Download</div>
-      </button>
     </div>
   </div>
 </ng-template>

--- a/src/app/metrics/metrics-filter/metrics-filter.component.html
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.html
@@ -1,12 +1,11 @@
 <form [formGroup]="form">
   <div class="row d-flex justify-content-between mb-4">
     <app-radio-buttons class="col-md-3 col-sm-12 mb-2 mb-md-0" [control]="fields?.timeSpan" [options]="timeSpanOptions"
-      [optionsLabels]="timeSpanLabels" [group]="false" [id]="'timeSpan'"
-      (inputChange)="presetRange($event)"></app-radio-buttons>
+      [optionsLabels]="timeSpanLabels" [group]="false" [id]="'timeSpan'" (inputChange)="presetRange()"></app-radio-buttons>
     <div class="col">
       <div class="d-flex flex-column flex-md-row justify-content-end">
         <app-shortdate-picker class="p-0 me-md-2 mb-2 mb-md-0" [range]="true" [control]="fields.dateRange"
-          [id]="'dateRange'" [maxDateRange]="366">
+          [id]="'dateRange'" [maxDateRange]="366" [icon]="'bi-calendar'">
         </app-shortdate-picker>
 
         <!-- medium screen or greater  -->
@@ -62,13 +61,12 @@
   <div class="m-4">
     <div class="row">
       <div class="col">
-        <app-picklist [label]="'Park'" [selectOptions]="parkOptions" [control]="fields.park" [id]="'downloadChartsPark'"
-          (inputChange)="parkChange($event)">
+        <app-picklist [label]="'Park'" [selectOptions]="parkOptions" [control]="fields.park" [id]="'downloadChartsPark'">
         </app-picklist>
       </div>
       <div class="col">
         <app-picklist [label]="'Facility'" [selectOptions]="facilityOptions" [placeholder]="'All Facilities'"
-          [control]="fields.facility" [id]="'downloadChartsFacility'" (inputChange)="facilityChange($event)">
+          [control]="fields.facility" [id]="'downloadChartsFacility'">
         </app-picklist>
       </div>
     </div>

--- a/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
@@ -39,6 +39,9 @@ describe('MetricsFilterComponent', () => {
           facility: mockFacility1.sk
         })
       }
+      if (id === Constants.dataIds.PARK_AND_FACILITY_LIST) {
+        return mockData;
+      }
       return new BehaviorSubject(null);
     }
   };
@@ -106,13 +109,14 @@ describe('MetricsFilterComponent', () => {
   })
 
   it('submits data correctly', async () => {
+    const params = { park: mockPark1.orcs, dateRange: mockDateRange, facility: mockFacility1.sk };
     const filterSpy = spyOn(component['metricsService'], 'setFilterParams');
-    await component.onSubmit();
+    await component.onSubmit(params);
     expect(filterSpy).not.toHaveBeenCalled();
     component.fields.park.setValue('all');
     filterSpy.calls.reset();
     component.fields.dateRange.setValue(mockDateRange);
-    await component.onSubmit();
+    await component.onSubmit(params);
     expect(filterSpy).toHaveBeenCalledWith({
       timeSpan: null,
       park: 'all',
@@ -123,7 +127,7 @@ describe('MetricsFilterComponent', () => {
     filterSpy.calls.reset();
     component.fields.facility.setValue(mockFacility1.sk);
     const dataSpy = spyOn(component['metricsService'], 'fetchData');
-    await component.onSubmit();
+    await component.onSubmit(params);
     expect(filterSpy).toHaveBeenCalledWith({
       timeSpan: null,
       park: mockPark1.sk,

--- a/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
@@ -121,7 +121,7 @@ describe('MetricsFilterComponent', () => {
       timeSpan: null,
       park: 'all',
       dateRange: mockDateRange,
-      facility: undefined
+      facility: null
     });
     component.fields.park.setValue(mockPark1.sk);
     filterSpy.calls.reset();

--- a/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.spec.ts
@@ -73,8 +73,8 @@ describe('MetricsFilterComponent', () => {
   });
 
   it('should have initial values', () => {
-    expect(component.timeSpanOptions).toEqual(['year', 'month', 'week']);
-    expect(component.timeSpanLabels).toEqual(['12M', '30D', '7D']);
+    expect(component.timeSpanOptions).toEqual(['week', 'month', 'year']);
+    expect(component.timeSpanLabels).toEqual(['7D', '30D', '12M']);
   });
 
   it('should populate park list', async () => {

--- a/src/app/metrics/metrics-filter/metrics-filter.component.ts
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.ts
@@ -41,9 +41,13 @@ export class MetricsFilterComponent extends BaseFormComponent {
     super(formBuilder, router, dataService, loadingService, changeDetector);
     this.subscriptions.add(
       this.dataService.watchItem(Constants.dataIds.PARK_AND_FACILITY_LIST).subscribe((res) => {
-        if (res) {
+        this.updateFilterParams();
+        if (res && !this.parkFacilitiesList) {
           this.parkFacilitiesList = res;
           this.createParksOptions(this.parkFacilitiesList);
+          if (this.data.park && this.data.park !== 'all') {
+            this.createFacilityOptions(this.parkFacilitiesList[this.data.park].facilities);
+          }
         }
       })
     )
@@ -66,7 +70,6 @@ export class MetricsFilterComponent extends BaseFormComponent {
       }
     }
     this.setForm();
-
   }
 
   setForm() {
@@ -98,8 +101,7 @@ export class MetricsFilterComponent extends BaseFormComponent {
 
   async updateFilterParams() {
     let res = await super.submit();
-    let fields = res.fields;
-    this.metricsService.setFilterParams(fields);
+    this.metricsService.setFilterParams(res?.fields);
   }
 
   async onSubmit(params) {
@@ -171,9 +173,9 @@ export class MetricsFilterComponent extends BaseFormComponent {
   }
 
   parkChange() {
-    const park = this.fields.park.value;
+    const park = this.fields?.park?.value;
     if (!park || park === 'all') {
-      this.fields.facility.setValue(undefined);
+      this.fields.facility.setValue(null);
       return;
     }
     if (this.parkFacilitiesList) {
@@ -183,6 +185,7 @@ export class MetricsFilterComponent extends BaseFormComponent {
         this.fields.facility.setValue(this.facilityOptions[2]?.value || this.facilityOptions[0]?.value || null);
       }
     }
+    return;
   }
 
   presetRange() {

--- a/src/app/metrics/metrics-filter/metrics-filter.component.ts
+++ b/src/app/metrics/metrics-filter/metrics-filter.component.ts
@@ -20,8 +20,8 @@ import { DateTime } from 'luxon';
 export class MetricsFilterComponent extends BaseFormComponent {
   public params;
   public parkFacilitiesList;
-  public timeSpanOptions = ['year', 'month', 'week'];
-  public timeSpanLabels = ['12M', '30D', '7D'];
+  public timeSpanOptions = ['week', 'month', 'year'];
+  public timeSpanLabels = ['7D', '30D', '12M'];
   public parkOptions = [];
   public facilityOptions = [];
   public metrics = [];
@@ -205,5 +205,9 @@ export class MetricsFilterComponent extends BaseFormComponent {
       }
       this.fields.dateRange.setValue([startDate, endDate]);
     }
+  }
+
+  unsetRange() {
+    this.fields.timeSpan.setValue(null);
   }
 }

--- a/src/app/metrics/site-metrics/site-metrics.component.html
+++ b/src/app/metrics/site-metrics/site-metrics.component.html
@@ -4,7 +4,7 @@
   <app-metrics-filter></app-metrics-filter>
   <div *ngIf="noData"
     class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2 empty-page mb-3 text-center">
-    {{loading ? 'Loading...' : 'Select date range or choose filters to display data.'}}
+    {{loading ? 'Loading...' : 'Select a date range display data.'}}
   </div>
   <div *ngIf="!noData">
     <!-- Loading element when API ready -->

--- a/src/app/metrics/site-metrics/site-metrics.component.html
+++ b/src/app/metrics/site-metrics/site-metrics.component.html
@@ -2,7 +2,11 @@
   <h1>Site Metrics</h1>
   <hr />
   <app-metrics-filter></app-metrics-filter>
-  <div>
+  <div *ngIf="noData"
+    class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2 empty-page mb-3 text-center">
+    {{loading ? 'Loading...' : 'Select date range or choose filters to display data.'}}
+  </div>
+  <div *ngIf="!noData">
     <!-- Loading element when API ready -->
     <div class="mb-4">
       <h2 *ngIf="parkName && !facilityName">Data for {{ parkName }}</h2>
@@ -32,8 +36,8 @@
           <div class="p-3 card h-100">
             <h4>Pass breakdown by status</h4>
             <div *ngIf="!doughnutData"
-              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2">
-              No passes found.
+              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2 text-center">
+              {{loading ? 'Loading...' : 'No passes found.'}}
             </div>
             <app-chart-metric *ngIf="doughnutData" class="d-block position-relative h-100" [type]="'doughnut'"
               [labels]="doughnutLabels" [datasets]="doughnutData" [options]="doughnutOptions"
@@ -44,8 +48,8 @@
           <div class="p-3 card" style="height: 450px">
             <h4>Pass activity by day</h4>
             <div *ngIf="!barChartData"
-              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2">
-              Please select a single facility to view daily pass activity.
+              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2 text-center">
+              {{loading ? 'Loading...' : 'Please select a single facility to view daily pass activity.'}}
             </div>
             <app-chart-metric *ngIf="singleFacility" class="h-100" [type]="'bar'" [labels]="barChartLabels"
               [datasets]="barChartData" [options]="barChartOptions" [plugins]="barChartPlugins"></app-chart-metric>

--- a/src/app/metrics/site-metrics/site-metrics.component.html
+++ b/src/app/metrics/site-metrics/site-metrics.component.html
@@ -1,86 +1,56 @@
 <div class="container-fluid">
   <h1>Site Metrics</h1>
   <hr />
-  <!--<app-metrics-filter></app-metrics-filter>-->
-  <!-- Temporary filler for report downloading -->
-  <div class="card">
-    <div class="card-body">
-      <h2>Export Report</h2>
-      <button
-        [disabled]="isGenerating"
-        class="btn btn-primary mr-1"
-        (click)="exportPassData()"
-      >
-        {{ buttonText }}&nbsp;
-        <div
-          style="vertical-align: middle"
-          *ngIf="isGenerating"
-          class="spinner-border"
-          role="status"
-        >
-          <span class="sr-only"></span>
-        </div>
-      </button>
-    </div>
-  </div>
+  <app-metrics-filter></app-metrics-filter>
   <div>
     <!-- Loading element when API ready -->
     <div class="mb-4">
-        <h2 *ngIf="parkName">Data for {{ parkName }}: {{ facilityName }}</h2>
-        <div class="row d-flex">
-          <div class="col-12 col-md-4 row flex-column mx-auto gy-3 justify-content-between">
-            <app-metric-card
-              class="metric-card px-0 mt-0"
-              [title]="'Total Number of Passes'"
-            >
-              <app-basic-metric [value]="passTotal"> </app-basic-metric>
-            </app-metric-card>
-            <app-metric-card
-              class="metric-card px-0"
-              [title]="'Active Passes'"
-            >
-              <app-basic-metric [value]="passActive"> </app-basic-metric>
-            </app-metric-card>
-            <app-metric-card
-              class="metric-card px-0"
-              [title]="'Reserved Passes'"
-            >
-              <app-basic-metric [value]="passReserved"> </app-basic-metric>
-            </app-metric-card>
-            <app-metric-card
-              class="metric-card px-0 mb-0"
-              [title]="'Expired Passes'"
-            >
-              <app-basic-metric [value]="passExpired"> </app-basic-metric>
-            </app-metric-card>
-          </div>
-          <div class="col-12 col-md-8 mt-0 pt-3">
-            <div class="p-3 card h-100">
-              <h4>Pass breakdown by status</h4>
-              <app-chart-metric
-                *ngIf="doughnutData"
-                class="d-block position-relative h-100"
-                [type]="'doughnut'"
-                [labels]="doughnutLabels"
-                [datasets]="doughnutData"
-                [options]="doughnutOptions"
-                [plugins]="doughnutPlugins"
-              ></app-chart-metric>
+      <h2 *ngIf="parkName && !facilityName">Data for {{ parkName }}</h2>
+      <h2 *ngIf="parkName && facilityName">Data for {{ parkName }}: {{ facilityName }}</h2>
+      <h3 *ngIf="dateRange && dateRange[0] === dateRange[1]">On {{dateRange[0] | date: 'longDate'}}</h3>
+      <h3 *ngIf="dateRange && dateRange[0] !== dateRange[1]">From {{dateRange[0] | date: 'longDate'}} to {{dateRange[1]
+        | date: 'longDate'}}</h3>
+      <div class="row d-flex">
+        <div class="col-12 col-md-4 row flex-column mx-auto gy-3 justify-content-between">
+          <app-metric-card class="metric-card px-0 mt-0" [title]="'Total Number of Passes'">
+            <app-basic-metric [value]="passTotals?.total" [animate]="true" [animationJitter]="true"> </app-basic-metric>
+          </app-metric-card>
+          <app-metric-card class="metric-card px-0" [title]="'Active Passes'">
+            <app-basic-metric [value]="passTotals?.active" [animate]="true" [animationJitter]="true">
+            </app-basic-metric>
+          </app-metric-card>
+          <app-metric-card class="metric-card px-0" [title]="'Reserved Passes'">
+            <app-basic-metric [value]="passTotals?.reserved" [animate]="true" [animationJitter]="true">
+            </app-basic-metric>
+          </app-metric-card>
+          <app-metric-card class="metric-card px-0 mb-0" [title]="'Expired Passes'">
+            <app-basic-metric [value]="passTotals?.expired" [animate]="true" [animationJitter]="true">
+            </app-basic-metric>
+          </app-metric-card>
+        </div>
+        <div class="col-12 col-md-8 mt-0 pt-3">
+          <div class="p-3 card h-100">
+            <h4>Pass breakdown by status</h4>
+            <div *ngIf="!doughnutData"
+              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2">
+              No passes found.
             </div>
+            <app-chart-metric *ngIf="doughnutData" class="d-block position-relative h-100" [type]="'doughnut'"
+              [labels]="doughnutLabels" [datasets]="doughnutData" [options]="doughnutOptions"
+              [plugins]="doughnutPlugins"></app-chart-metric>
           </div>
-          <div *ngIf="scatterData" class="col-12 mt-0 pt-3">
-            <div class="p-3 card h-100">
-              <h4>Pass activity by day</h4>
-              <app-chart-metric
-                class="d-block position-relative h-100"
-                [type]="'doughnut'"
-                [labels]="scatterLabels"
-                [datasets]="scatterData"
-                [options]="scatterOptions"
-                [plugins]="scatterPlugins"
-              ></app-chart-metric>
+        </div>
+        <div class="col-12 mt-0 pt-3">
+          <div class="p-3 card" style="height: 450px">
+            <h4>Pass activity by day</h4>
+            <div *ngIf="!barChartData"
+              class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2">
+              Please select a single facility to view daily pass activity.
             </div>
+            <app-chart-metric *ngIf="singleFacility" class="h-100" [type]="'bar'" [labels]="barChartLabels"
+              [datasets]="barChartData" [options]="barChartOptions" [plugins]="barChartPlugins"></app-chart-metric>
           </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/metrics/site-metrics/site-metrics.component.html
+++ b/src/app/metrics/site-metrics/site-metrics.component.html
@@ -49,9 +49,14 @@
             <h4>Pass activity by day</h4>
             <div *ngIf="!barChartData"
               class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-2 text-center">
-              {{loading ? 'Loading...' : 'Please select a single facility to view daily pass activity.'}}
+              <div *ngIf="loading">
+                Loading...
+              </div>
+              <div *ngIf="!loading">
+                {{singleFacility ? 'No data.' : 'Please select a single facility to view daily pass activity.'}}
+              </div>
             </div>
-            <app-chart-metric *ngIf="singleFacility" class="h-100" [type]="'bar'" [labels]="barChartLabels"
+            <app-chart-metric *ngIf="singleFacility && barChartData" class="h-100" [type]="'bar'" [labels]="barChartLabels"
               [datasets]="barChartData" [options]="barChartOptions" [plugins]="barChartPlugins"></app-chart-metric>
           </div>
         </div>

--- a/src/app/metrics/site-metrics/site-metrics.component.scss
+++ b/src/app/metrics/site-metrics/site-metrics.component.scss
@@ -1,0 +1,4 @@
+.empty-page{
+  min-height: 600px;
+  border-radius: 5px;
+}

--- a/src/app/metrics/site-metrics/site-metrics.component.spec.ts
+++ b/src/app/metrics/site-metrics/site-metrics.component.spec.ts
@@ -21,14 +21,26 @@ describe('SiteMetricsComponent', () => {
   let buildSpy;
   const testSk = '37bbecdf38089efe13af862dc9d6f460'
 
-  let testMetricsData1 = MockData.metricsData1;
-  let testMetricsData2 = MockData.metricsData2;
 
-  let testSubject = new BehaviorSubject(testMetricsData1);
+  let mockParksAndFacilities = MockData.mockParkFacility_1;
+  let mockDateRange = ['2023-01-30', '2023-02-01'];
+  let mockMetricsData = MockData.mockMetrics1;
+  let mockMetricsParams = {
+    timeSpan: null,
+    park: MockData.mockPark_1.sk,
+    facility: MockData.mockFacility_1.sk,
+    dateRange: mockDateRange
+  }
 
   let fakeDataService = {
-    watchItem: () => {
-      return testSubject;
+    watchItem: (id) => {
+      if (id === Constants.dataIds.CURRENT_METRICS)
+        return new BehaviorSubject([mockMetricsData]);
+      if (id === Constants.dataIds.METRICS_FILTERS_PARAMS)
+        return new BehaviorSubject(mockMetricsParams);
+      if (id === Constants.dataIds.PARK_AND_FACILITY_LIST)
+        return new BehaviorSubject(mockParksAndFacilities);
+      return new BehaviorSubject(null);
     },
   };
 
@@ -44,7 +56,7 @@ describe('SiteMetricsComponent', () => {
 
     fixture = TestBed.createComponent(SiteMetricsComponent);
     component = fixture.componentInstance;
-    buildSpy = spyOn(component, 'buildCharts').and.callThrough();
+    buildSpy = spyOn(component, 'buildDoughnutChart').and.callThrough();
     fixture.detectChanges();
   });
 
@@ -54,48 +66,35 @@ describe('SiteMetricsComponent', () => {
     expect(buildSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('should load metrics data into component', async () => {
-    let data = testMetricsData1;
-    expect(component.passActive).toEqual(data.active);
-    expect(component.passExpired).toEqual(data.expired);
-    expect(component.passReserved).toEqual(data.reserved);
-    expect(component.passExpired).toEqual(data.expired);
-  });
-
-  it('should update metrics with new data', async () => {
-    let data = testMetricsData2;
-
-    component.buildCharts(data);
-
-    await fixture.isStable();
-    expect(component.passActive).toEqual(data.active);
-    expect(component.passExpired).toEqual(data.expired);
-    expect(component.passReserved).toEqual(data.reserved);
-    expect(component.passExpired).toEqual(data.expired);
-  });
-
-  it('should handle generate export report click', fakeAsync(async () => {
-    let getPassExportSpy = spyOn(component, 'getPassExport');
-    let apiSpy = spyOn(component['apiService'], 'get').and.returnValue(
-      new BehaviorSubject({
-        status: 'Export job created',
-        sk: '37bbecdf38089efe13af862dc9d6f460',
-      })
-    );
-
-    const buttons =
-      fixture.debugElement.nativeElement.querySelectorAll('button');
-    buttons[0].click();
-    tick(1200);
+  it('should parse statusData', async () => {
+    component.getStatusData();
     await fixture.isStable();
     fixture.detectChanges();
+    expect(component['passTotals']).toEqual({
+      active: 5,
+      reserved: 3,
+      expired: 1,
+      cancelled: 4,
+      total: 9
+    });
+  });
 
-    expect(getPassExportSpy).toHaveBeenCalledTimes(1);
-    expect(apiSpy).toHaveBeenCalledTimes(1);
-    expect(component.isGenerating).toBeTrue();
-    expect(component.signedURL).toBeNull();
-    expect(component.statusMessage).toBeTruthy();
-  }));
+  it('should parse capacityData', async () => {
+    let date = mockMetricsData.sk;
+    component.dateInterval = component.createDateInterval(date, date);
+    let capacityData = component.getCapacityData();
+    await fixture.isStable();
+    fixture.detectChanges();
+    expect(capacityData).toEqual({
+      [date]: {
+        booked: 9,
+        capacity: 24,
+        cancelled: 4
+      }
+    });
+  });
+
+
 
   it('should test when API call finds no export report', async () => {
     let toastService = spyOn(component['toastService'], 'addMessage')

--- a/src/app/metrics/site-metrics/site-metrics.component.spec.ts
+++ b/src/app/metrics/site-metrics/site-metrics.component.spec.ts
@@ -81,20 +81,16 @@ describe('SiteMetricsComponent', () => {
 
   it('should parse capacityData', async () => {
     let date = mockMetricsData.sk;
-    component.dateInterval = component.createDateInterval(date, date);
+    component.dateInterval = ['2023-01-30', '2023-01-31', '2023-02-01'];
     let capacityData = component.getCapacityData();
     await fixture.isStable();
     fixture.detectChanges();
-    expect(capacityData).toEqual({
-      [date]: {
-        booked: 9,
-        capacity: 24,
-        cancelled: 4
-      }
+    expect(capacityData[date]).toEqual({
+      booked: 9,
+      capacity: 24,
+      cancelled: 4
     });
   });
-
-
 
   it('should test when API call finds no export report', async () => {
     let toastService = spyOn(component['toastService'], 'addMessage')

--- a/src/app/metrics/site-metrics/site-metrics.component.ts
+++ b/src/app/metrics/site-metrics/site-metrics.component.ts
@@ -1,52 +1,52 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ToastService } from '../../services/toast.service';
 import { ApiService } from '../../services/api.service';
 import { Constants } from '../../shared/utils/constants';
 import { firstValueFrom, Subscription } from 'rxjs';
 import { DataService } from '../../services/data.service';
 import { LoadingService } from '../../services/loading.service';
+import { ChartPlugins } from 'src/app/shared/components/metrics/chart-metric/chart-metric-plugins';
+import { DateTime, Interval } from 'luxon';
 
 @Component({
   selector: 'app-site-metrics',
   templateUrl: './site-metrics.component.html',
   styleUrls: ['./site-metrics.component.scss'],
 })
-export class SiteMetricsComponent implements OnDestroy {
+export class SiteMetricsComponent implements OnDestroy, OnInit {
   private subscriptions = new Subscription();
   public loading: boolean = false;
 
-  parkName: string;
-  facilityName: string;
-  passStatusChart;
+  public metrics;
+  public parksAndFacilities;
+  public dateRange;
+  public dateInterval;
+  public filterParams;
+  public singleFacility = false;
+  public timezone = 'America/Vancouver';
+  public passTotals = {
+    active: 0,
+    reserved: 0,
+    expired: 0,
+    cancelled: 0,
+    total: 0
+  }
+  public parkName: string;
+  public facilityName: string;
+  public doughnutLabels: any;
+  public doughnutData: any;
+  public doughnutOptions: any;
+  public doughnutPlugins: any;
+  public barChartLabels: any;
+  public barChartData: any;
+  public barChartOptions: any;
+  public barChartPlugins = [ChartPlugins.barHighlightColumnPlugin];
+
   passExport;
   isGenerating: any = false;
   statusMessage: any;
   signedURL: any;
   buttonText: any = 'Export Pass Data';
-  doughnutLabels: any;
-  doughnutData: any;
-  doughnutOptions: any = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        labels: {
-          font: {
-            size: 20,
-          },
-        },
-      },
-    },
-  };
-  doughnutPlugins: any;
-  scatterLabels: any;
-  scatterData: any;
-  scatterOptions: any;
-  scatterPlugins: any;
-  passTotal: number = undefined;
-  passActive: number = undefined;
-  passReserved: number = undefined;
-  passExpired: number = undefined;
 
   constructor(
     private apiService: ApiService,
@@ -56,10 +56,33 @@ export class SiteMetricsComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.PASS_BREAKDOWN_BY_STATUS)
+        .watchItem(Constants.dataIds.PARK_AND_FACILITY_LIST)
         .subscribe((res) => {
           if (res) {
-            this.buildCharts(res);
+            this.parksAndFacilities = res;
+          }
+        })
+    );
+
+    this.subscriptions.add(
+      dataService
+        .watchItem(Constants.dataIds.METRICS_FILTERS_PARAMS)
+        .subscribe((res) => {
+          if (res) {
+            this.filterParams = res;
+            this.parseFilterParams();
+          }
+        })
+    );
+
+    this.subscriptions.add(
+      dataService
+        .watchItem(Constants.dataIds.CURRENT_METRICS)
+        .subscribe((res) => {
+          if (res) {
+            this.metrics = res;
+            this.parseFilterParams();
+            this.parseMetrics();
           }
         })
     );
@@ -71,43 +94,204 @@ export class SiteMetricsComponent implements OnDestroy {
     );
   }
 
-  buildCharts(res) {
-    let data: string[] = [];
-    let labels: string[] = [];
-    let passTotal: number = 0;
+  ngOnInit() {
+    //set up chart settings
+    this.doughnutOptions = {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          labels: {
+            font: {
+              size: 20,
+            },
+          },
+        },
+      },
+    };
+    this.barChartOptions = {
+      scales: {
+        x: {
+          grid: {
+            display: false
+          }
+        },
+        y: {
+          grid: {
+            display: false
+          }
+        }
+      },
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        tooltip: {
+          intersect: false,
+          mode: 'index',
+        },
+        legend: {
+          labels: {
+            font: {
+              size: 20,
+            },
+          },
+        },
+      },
+    };
+    this.barChartPlugins = [ChartPlugins.barHighlightColumnPlugin];
+  }
 
-    for (const item of Object.keys(res)) {
-      labels.push(item);
-      data.push(res[item]);
-      passTotal += res[item];
-      switch (item) {
-        case Constants.stateLabelDictionary.active.state:
-          this.passActive = res[item];
-          break;
-        case Constants.stateLabelDictionary.reserved.state:
-          this.passReserved = res[item];
-          break;
-        case Constants.stateLabelDictionary.expired.state:
-          this.passExpired = res[item];
-          break;
+  parseFilterParams() {
+    if (this.filterParams?.park) {
+      if (this.filterParams?.park === 'all') {
+        this.parkName = 'All Parks';
+      } else {
+        this.parkName = this.parksAndFacilities[this.filterParams.park]?.name;
+      }
+      if (this.filterParams?.facility === 'all') {
+        this.singleFacility = false;
+        this.facilityName = 'All Facilities';
+      } else {
+        this.singleFacility = true;
+        this.facilityName = this.parksAndFacilities[this.filterParams.park]?.facilities?.[this.filterParams.facility]?.name;
+      }
+      this.dateRange = [this.filterParams.dateRange[0], this.filterParams.dateRange[1]];
+      this.dateInterval = this.createDateInterval(this.dateRange[0], this.dateRange[1]);
+    }
+  }
+
+  createDateInterval(startDate, endDate) {
+    const interval = Interval.fromDateTimes(
+      DateTime.fromISO(startDate).setZone(this.timezone).startOf('day'),
+      DateTime.fromISO(endDate).setZone(this.timezone).endOf('day'),
+    ).splitBy({ day: 1 }).map(d => d.start.toISODate());
+    return interval;
+  }
+
+  parseMetrics() {
+    if (this.metrics.length) {
+      this.getStatusData();
+      this.buildDoughnutChart(this.passTotals.active, this.passTotals.reserved, this.passTotals.expired, this.passTotals.cancelled);
+      if (this.singleFacility && this.dateRange) {
+        let capacityData = this.getCapacityData();
+        this.buildBarChart(capacityData);
+      } else {
+        this.barChartData = null;
       }
     }
+  }
 
-    this.passTotal = passTotal;
-    this.doughnutData = [
+  getStatusData() {
+    let statusData = {};
+    this.passTotals = {
+      active: 0,
+      reserved: 0,
+      expired: 0,
+      cancelled: 0,
+      total: 0
+    }
+    for (const metric of this.metrics) {
+      this.passTotals.total += metric.totalPasses;
+      let date = metric.sk;
+      if (!statusData[date]) {
+        statusData[date] = {
+          active: 0,
+          reserved: 0,
+          expired: 0,
+          cancelled: 0
+        }
+      }
+      for (const time in metric.capacities) {
+        for (const status in statusData[date]) {
+          statusData[date][status] += metric.capacities[time].passStatuses?.[status] || 0;
+        }
+      }
+    }
+    for (const day in statusData) {
+      this.passTotals.active += statusData[day].active;
+      this.passTotals.reserved += statusData[day].reserved;
+      this.passTotals.expired += statusData[day].expired;
+      this.passTotals.cancelled += statusData[day].cancelled;
+    }
+  }
+
+  getCapacityData() {
+    let capacityData = {};
+    for (const date of this.dateInterval) {
+      capacityData[date] = {
+        booked: 0,
+        capacity: 0,
+        cancelled: 0
+      }
+      const metricsList = this.metrics.filter((item) => item.sk === date);
+      for (const metric of metricsList) {
+        for (const time in metric.capacities) {
+          const timeSlot = metric.capacities[time];
+          capacityData[date].booked += timeSlot.baseCapacity + timeSlot.capacityModifier + timeSlot.overbooked - timeSlot.availablePasses;
+          capacityData[date].capacity += timeSlot.baseCapacity + timeSlot.capacityModifier;
+          capacityData[date].cancelled += timeSlot.passStatuses?.cancelled || 0;
+        }
+      }
+    }
+    return capacityData;
+  }
+
+  buildDoughnutChart(active, reserved, expired, cancelled) {
+    const data = {
+      active: active,
+      reserved: reserved,
+      expired: expired,
+      cancelled: cancelled
+    }
+
+    this.doughnutLabels = Object.keys(data);
+    if (this.passTotals.total > 0) {
+      this.doughnutData = [
+        {
+          data: Object.values(data),
+          backgroundColor: [
+            '#75b343', //active
+            '#205d38', //reserved
+            '#fdb813', //expired
+            '#E4E4E4', //cancelled
+          ],
+        }
+      ]
+    } else {
+      this.doughnutData = null;
+    }
+  }
+
+  buildBarChart(capacityData) {
+    let data = {
+      booked: [],
+      capacity: [],
+      cancelled: []
+    }
+    for (const item in capacityData) {
+      data.booked.push(capacityData[item].booked);
+      data.capacity.push(capacityData[item].capacity);
+      data.cancelled.push(capacityData[item].cancelled);
+    }
+
+    this.barChartLabels = Object.keys(capacityData);
+    this.barChartData = [
       {
-        data: data,
-        backgroundColor: [
-          '#E4E4E4', //cancelled
-          '#75b343', //active
-          '#205d38', //reserved
-          '#fdb813', //expired
-        ],
+        label: 'booked',
+        data: data.booked,
+        backgroundColor: '#C1D9F2', //active
       },
-    ];
-    this.doughnutLabels = labels;
-
-    //TBD: set data for bar chart
+      {
+        label: 'capacity',
+        data: data.capacity,
+        backgroundColor: '#2464A4', //reserved
+      },
+      {
+        label: 'cancelled',
+        data: data.cancelled,
+        backgroundColor: '#003366', //cancelled
+      },
+    ]
   }
 
   async exportPassData() {

--- a/src/app/metrics/site-metrics/site-metrics.component.ts
+++ b/src/app/metrics/site-metrics/site-metrics.component.ts
@@ -188,6 +188,15 @@ export class SiteMetricsComponent implements OnDestroy, OnInit {
       } else {
         this.barChartData = null;
       }
+    } else {
+      this.barChartData = null;
+      this.passTotals = {
+        active: 0,
+        reserved: 0,
+        expired: 0,
+        cancelled: 0,
+        total: 0
+      }
     }
   }
 

--- a/src/app/metrics/site-metrics/site-metrics.component.ts
+++ b/src/app/metrics/site-metrics/site-metrics.component.ts
@@ -41,6 +41,7 @@ export class SiteMetricsComponent implements OnDestroy, OnInit {
   public barChartData: any;
   public barChartOptions: any;
   public barChartPlugins = [ChartPlugins.barHighlightColumnPlugin];
+  public noData = false;
 
   passExport;
   isGenerating: any = false;
@@ -69,6 +70,9 @@ export class SiteMetricsComponent implements OnDestroy, OnInit {
         .watchItem(Constants.dataIds.METRICS_FILTERS_PARAMS)
         .subscribe((res) => {
           if (res) {
+            this.barChartData = null;
+            this.doughnutData = null;
+            this.singleFacility = false;
             this.filterParams = res;
             this.parseFilterParams();
           }
@@ -144,19 +148,25 @@ export class SiteMetricsComponent implements OnDestroy, OnInit {
   parseFilterParams() {
     if (this.filterParams?.park) {
       if (this.filterParams?.park === 'all') {
+        this.singleFacility = false;
         this.parkName = 'All Parks';
       } else {
         this.parkName = this.parksAndFacilities[this.filterParams.park]?.name;
+        if (this.filterParams?.facility === 'all') {
+          this.singleFacility = false;
+          this.facilityName = 'All Facilities';
+        } else {
+          this.singleFacility = true;
+          this.facilityName = this.parksAndFacilities[this.filterParams.park]?.facilities?.[this.filterParams.facility]?.name;
+        }
       }
-      if (this.filterParams?.facility === 'all') {
-        this.singleFacility = false;
-        this.facilityName = 'All Facilities';
+      if (this.filterParams.dateRange) {
+        this.dateRange = [this.filterParams.dateRange[0], this.filterParams.dateRange[1]];
+        this.dateInterval = this.createDateInterval(this.dateRange[0], this.dateRange[1]);
+        this.noData = false;
       } else {
-        this.singleFacility = true;
-        this.facilityName = this.parksAndFacilities[this.filterParams.park]?.facilities?.[this.filterParams.facility]?.name;
+        this.noData = true;
       }
-      this.dateRange = [this.filterParams.dateRange[0], this.filterParams.dateRange[1]];
-      this.dateInterval = this.createDateInterval(this.dateRange[0], this.dateRange[1]);
     }
   }
 

--- a/src/app/resolvers/metrics.resolver.spec.ts
+++ b/src/app/resolvers/metrics.resolver.spec.ts
@@ -1,0 +1,70 @@
+import { HttpClient, HttpHandler } from "@angular/common/http";
+import { TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { BehaviorSubject } from "rxjs";
+import { ConfigService } from "../services/config.service";
+import { DataService } from "../services/data.service";
+import { MockData } from "../shared/utils/mock-data";
+import { MetricsResolver } from "./metrics.resolver";
+
+describe('ParkResolver', () => {
+  let resolver: MetricsResolver;
+  let route: ActivatedRoute;
+
+  let mockActivatedRoute = {
+    snapshot: {
+      params: {
+        parkId: 'MOC1',
+      },
+    },
+  };
+  let mockDateRange = ['2023-01-30', '2023-02-01'];
+  let mockMetricsParams = {
+    timeSpan: null,
+    park: MockData.mockPark_1.sk,
+    facility: MockData.mockFacility_1.sk,
+    dateRange: mockDateRange
+  }
+
+  let mockParkFacility1 = MockData.mockParkFacility_1;
+
+  let mockDataService = {
+    getItemValue: () => {
+      return new BehaviorSubject(mockMetricsParams);
+    },
+    setItemValue: () => {
+      return new BehaviorSubject(null);
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        HttpClient,
+        HttpHandler,
+        ConfigService,
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: DataService, useValue: mockDataService },
+      ],
+    });
+    resolver = TestBed.inject(MetricsResolver);
+    route = TestBed.inject(ActivatedRoute);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+
+  it('should not preset params if they exist', async () => {
+    resolver.resolve();
+    const filterSpy = spyOn(resolver['metricsService'], 'setFilterParams');
+    expect(filterSpy).not.toHaveBeenCalled();
+  })
+
+  it('should preset params if they do not exist', async () => {
+    const filterSpy = spyOn(resolver['metricsService'], 'setFilterParams');
+    mockMetricsParams = null;
+    resolver.resolve();
+    expect(filterSpy).toHaveBeenCalled();
+  })
+});

--- a/src/app/resolvers/metrics.resolver.ts
+++ b/src/app/resolvers/metrics.resolver.ts
@@ -1,13 +1,26 @@
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
+import { DataService } from '../services/data.service';
+import { Constants } from '../shared/utils/constants';
+import { DateTime } from 'luxon';
 import { MetricsService } from '../services/metrics.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MetricsResolver implements Resolve<void> {
-  constructor(private metricsService: MetricsService) {}
+  constructor(
+    private metricsService: MetricsService,
+    private dataService: DataService
+  ) { }
   resolve() {
-    this.metricsService.fetchData('passTotals');
+    const params = this.dataService.getItemValue(Constants.dataIds.METRICS_FILTERS_PARAMS);
+    if (!params || !params.dateRange) {
+      // set date to today
+      const today = DateTime.now().setZone('America/Vancouver').toISODate();
+      this.metricsService.setFilterParams({
+        dateRange: [today, today],
+      })
+    }
   }
 }

--- a/src/app/resolvers/metrics.resolver.ts
+++ b/src/app/resolvers/metrics.resolver.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
 import { DataService } from '../services/data.service';
 import { Constants } from '../shared/utils/constants';
-import { DateTime } from 'luxon';
 import { MetricsService } from '../services/metrics.service';
 
 @Injectable({
@@ -15,11 +14,12 @@ export class MetricsResolver implements Resolve<void> {
   ) { }
   resolve() {
     const params = this.dataService.getItemValue(Constants.dataIds.METRICS_FILTERS_PARAMS);
-    if (!params || !params.dateRange) {
-      // set date to today
-      const today = DateTime.now().setZone('America/Vancouver').toISODate();
+    if (!params || !params.park) {
       this.metricsService.setFilterParams({
-        dateRange: [today, today],
+        dateRange: null,
+        park: 'all',
+        facility: null,
+        timeSpan: null
       })
     }
   }

--- a/src/app/services/metrics.service.spec.ts
+++ b/src/app/services/metrics.service.spec.ts
@@ -1,0 +1,97 @@
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject } from 'rxjs';
+import { Constants } from '../shared/utils/constants';
+import { MockData } from '../shared/utils/mock-data';
+import { ApiService } from './api.service';
+import { ConfigService } from './config.service';
+import { DataService } from './data.service';
+import { LoggerService } from './logger.service';
+
+import { MetricsService } from './metrics.service';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+
+  let mockMetrics = MockData.mockMetrics1;
+  let mockParkFacilities = MockData.mockParkFacility_1;
+
+  let mockApiService = {
+    get: (id, params) => {
+      if (id === 'metrics') {
+        return new BehaviorSubject([mockMetrics])
+      }
+      return new BehaviorSubject(null);
+    },
+  }
+
+  let mockDataService = {
+    setItemValue: (id, data) => {
+      return new BehaviorSubject(null);
+    },
+    getItemValue: (id) => {
+      if (id === Constants.dataIds.PARK_AND_FACILITY_LIST) {
+        return mockParkFacilities;
+      }
+      return new BehaviorSubject(null);
+    }
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        HttpClient,
+        HttpHandler,
+        ConfigService,
+        LoggerService,
+        { provide: ApiService, useValue: mockApiService },
+        { provide: DataService, useValue: mockDataService },
+      ],
+      imports: [RouterTestingModule],
+    });
+    service = TestBed.inject(MetricsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('fetches all metrics from all parks', async () => {
+    const apiSpy = spyOn(service['apiService'], 'get').and.callThrough();
+    await service.fetchData('2023-01-31');
+    // call api once for every facility in every park
+    let facilityCount = 0;
+    for (const park in mockParkFacilities) {
+      facilityCount += Object.keys(mockParkFacilities[park].facilities).length;
+    }
+    expect(apiSpy).toHaveBeenCalledTimes(facilityCount);
+  });
+
+  it('fetches all metrics from all facilities in a park', async () => {
+    const apiSpy = spyOn(service['apiService'], 'get').and.callThrough();
+    const parkSk = Object.keys(mockParkFacilities)[0];
+    await service.fetchData('2023-01-31', '2023-01-31', parkSk);
+    // call api once for every facility in parkSk
+    let facilityCount = Object.keys(mockParkFacilities[parkSk].facilities).length;
+    expect(apiSpy).toHaveBeenCalledTimes(facilityCount);
+  })
+
+  it('fetches all metrics from one facility', async () => {
+    const apiSpy = spyOn(service['apiService'], 'get').and.callThrough();
+    const parkSk = Object.keys(mockParkFacilities)[0];
+    const facilitySk = Object.keys(mockParkFacilities[parkSk].facilities)[0];
+    // should call api just once
+    await service.fetchData('2023-01-31', '2023-01-31', parkSk, facilitySk);
+    expect(apiSpy).toHaveBeenCalledTimes(1);
+  })
+
+  it('sets filter params', async () => {
+    const filterSpy = spyOn(service['dataService'], 'setItemValue');
+    service.setFilterParams('params');
+    expect(filterSpy).toHaveBeenCalledWith(
+      Constants.dataIds.METRICS_FILTERS_PARAMS,
+      'params'
+    )
+  })
+});

--- a/src/app/services/metrics.service.ts
+++ b/src/app/services/metrics.service.ts
@@ -52,6 +52,7 @@ export class MetricsService {
     try {
       this.loadingService.addToFetchList(dataTag); 0
       let data = [];
+      this.dataService.setItemValue(dataTag, null);
       for (const item in getList) {
         for (const facility of getList[item]) {
           const res = await firstValueFrom(

--- a/src/app/services/metrics.service.ts
+++ b/src/app/services/metrics.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import { Constants } from '../shared/utils/constants';
-import { ApiService } from './api.service';
-import { EventKeywords, EventObject, EventService } from './event.service';
-import { LoadingService } from './loading.service';
-import { ToastService } from './toast.service';
-import { firstValueFrom } from 'rxjs';
-import { DataService } from './data.service';
+import { Injectable } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
+import { Constants } from "../shared/utils/constants";
+import { ApiService } from "./api.service";
+import { DataService } from "./data.service";
+import { EventKeywords, EventObject, EventService } from "./event.service";
+import { LoadingService } from "./loading.service";
+import { ToastService } from "./toast.service";
 
 @Injectable({
   providedIn: 'root',
@@ -14,24 +14,59 @@ import { DataService } from './data.service';
 export class MetricsService {
   constructor(
     private apiService: ApiService,
-    private eventService: EventService,
+    private dataService: DataService,
     private toastService: ToastService,
-    private router: Router,
-    private route: ActivatedRoute,
+    private eventService: EventService,
     private loadingService: LoadingService,
-    private dataService: DataService
-  ) {}
+    private router: Router,
+    private route: ActivatedRoute
+  ) { }
 
-  async fetchData(metric): Promise<any> {
+
+  async fetchData(startDate, endDate?, parkSk?, facilitySk?): Promise<any> {
     const errorSubject = 'metrics';
-    const dataTag = Constants.dataIds.PASS_BREAKDOWN_BY_STATUS;
+    const dataTag = Constants.dataIds.CURRENT_METRICS;
+    const parksAndFacilities = this.dataService.getItemValue(Constants.dataIds.PARK_AND_FACILITY_LIST);
+
+    let parkList = [];
+    let getList = [];
+
+    if (!parkSk) {
+      // Get from all parks
+      parkList = Object.keys(parksAndFacilities);
+    } else {
+      // Get from 1 park
+      parkList = [parkSk]
+    }
+
+    for (const park of parkList) {
+      if (!facilitySk) {
+        // Get from all facilities in park
+        getList[park] = Object.keys(parksAndFacilities[park].facilities);
+      } else {
+        // Get from 1 facility
+        getList[park] = [facilitySk];
+      }
+    }
 
     try {
-      this.loadingService.addToFetchList(dataTag);
-      const res = await firstValueFrom(
-        this.apiService.get('metric', { type: metric })
-      );
-      this.dataService.setItemValue(dataTag, res);
+      this.loadingService.addToFetchList(dataTag); 0
+      let data = [];
+      for (const item in getList) {
+        for (const facility of getList[item]) {
+          const res = await firstValueFrom(
+            this.apiService.get(
+              'metrics',
+              {
+                park: item,
+                facility: facility,
+                startDate: startDate,
+                endDate: endDate || null
+              }));
+          data = data.concat(res);
+        }
+      }
+      this.dataService.setItemValue(dataTag, data);
     } catch (e) {
       this.toastService.addMessage(
         `An error has occured while getting ${errorSubject}.`,
@@ -39,10 +74,24 @@ export class MetricsService {
         Constants.ToastTypes.ERROR
       );
       this.eventService.setError(
-        new EventObject(EventKeywords.ERROR, e as string, 'Metric Service')
+        new EventObject(EventKeywords.ERROR, e as string, 'Metrics Service')
       );
       this.router.navigate(['../', { relativeTo: this.route }]);
     }
     this.loadingService.removeToFetchList(dataTag);
   }
+
+  /**
+   *   fields should have the following format at minimum: 
+   * fields = {
+   * park: park,
+   * facility: facility,
+   * dateRange: [startDate, endDate]
+   * timeSpan: timeSpan,
+   * }
+   */
+  setFilterParams(fields) {
+    this.dataService.setItemValue(Constants.dataIds.METRICS_FILTERS_PARAMS, fields);
+  }
+
 }

--- a/src/app/shared/components/ds-forms/base-form/base-form.component.ts
+++ b/src/app/shared/components/ds-forms/base-form/base-form.component.ts
@@ -212,7 +212,7 @@ export class BaseFormComponent implements OnDestroy, AfterContentInit {
    */
   async disable() {
     await setTimeout(() => {
-      this.form.disable();
+      this.form.disable({emitEvent: false});
     });
   }
 
@@ -229,7 +229,7 @@ export class BaseFormComponent implements OnDestroy, AfterContentInit {
           continue;
         } else {
           setTimeout(() => {
-            control.enable();
+            control.enable({emitEvent: false});
           });
         }
       }

--- a/src/app/shared/components/ds-forms/base-input/base-input.component.ts
+++ b/src/app/shared/components/ds-forms/base-input/base-input.component.ts
@@ -31,12 +31,14 @@ export class BaseInputComponent implements OnInit, OnDestroy {
   public controlInitialized = new BehaviorSubject(false);
 
   constructor(
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.subscriptions.add(
       this.control.valueChanges.subscribe((res) => {
-        this.inputChange.emit(res);
+        if (res) {
+          this.inputChange.emit(res);
+        }
       })
     );
     this.controlInitialized.next(true);

--- a/src/app/shared/components/ds-forms/picklist/picklist.component.html
+++ b/src/app/shared/components/ds-forms/picklist/picklist.component.html
@@ -24,11 +24,13 @@
     <option selected *ngIf="defaultNullDisplay" value="null">
       {{ defaultNullDisplay }}
     </option>
-    <option
-      *ngFor="let option of selectOptions; index as i"
-      value="{{ option?.value }}"
-    >
-      {{ option?.display }}
+    <option *ngFor="let option of selectOptions; index as i" value="{{ option?.value }}" [disabled]="option?.disabled">
+      <div *ngIf="!option?.breakpoint">
+        {{ option?.display }}
+      </div>
+      <div *ngIf="option?.breakpoint" class="text-light">
+        {{drawStrikeoutBar()}}
+      </div>
     </option>
   </select>
 </div>

--- a/src/app/shared/components/ds-forms/picklist/picklist.component.ts
+++ b/src/app/shared/components/ds-forms/picklist/picklist.component.ts
@@ -9,4 +9,8 @@ import { BaseInputComponent } from '../base-input/base-input.component';
 export class PicklistComponent extends BaseInputComponent {
   @Input() selectOptions;
   @Input() defaultNullDisplay;
+
+  drawStrikeoutBar() {
+    return ('─').repeat(25);
+  }
 }

--- a/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.html
+++ b/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.html
@@ -47,9 +47,14 @@
 
   <div
     class="input-group-text clear-button"
-    (click)="clearDate()"
-    title="Clear Date"
-  >
-    <i class="bi bi-x-lg"></i>
+    >
+    <div *ngIf="control?.enabled"
+      title="Clear Date"
+      (click)="clearDate()">
+      <i class="bi bi-x-lg"></i>
+    </div>
+    <div *ngIf="!control?.enabled">
+      <i class="spinner-border spinner-border-sm"></i>
+    </div>
   </div>
 </div>

--- a/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.html
+++ b/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.html
@@ -39,8 +39,9 @@
     type="text"
     name="{{ id }}"
     [minDate]="minDate"
+    [maxDate]="maxDate"
     [(ngModel)]="modelDate"
-    [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD' }"
+    [bsConfig]="{ rangeInputFormat: 'YYYY-MM-DD', maxDateRange: maxDateRange }"
     (ngModelChange)="onDateChange()"
   />
 

--- a/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.ts
+++ b/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.ts
@@ -11,18 +11,18 @@ import { BaseInputComponent } from '../base-input/base-input.component';
   styleUrls: ['./shortdate-picker.component.scss'],
 })
 export class ShortdatePickerComponent
-  extends BaseInputComponent
-{
+  extends BaseInputComponent {
   @Input() minDate: Date = null as any;
   @Input() maxDate: Date = null as any;
   @Input() range: boolean = false;
+  @Input() maxDateRange: number = 366; // 1 year is the default max range
 
   public modelDate;
 
   private utils = new Utils();
 
   constructor(
-  ){
+  ) {
     super();
     this.subscriptions.add(
       this.controlInitialized.subscribe((value) => {
@@ -34,10 +34,24 @@ export class ShortdatePickerComponent
   }
 
   initializeControl() {
-    this.modelDate = this.control?.value || null;
+    if (this.range) {
+      this.modelDate = [
+        this.utils.convertShortDateToJSDate(this.control.value[0] || null),
+        this.utils.convertShortDateToJSDate(this.control.value[1] || null)
+      ];
+    } else {
+      this.modelDate = this.control.value || null;
+    }
     this.subscriptions.add(
       this.control.valueChanges.subscribe((res) => {
-        this.modelDate = res || null;
+        if (this.range && res) {
+          this.modelDate = [
+            this.utils.convertShortDateToJSDate(res[0]),
+            this.utils.convertShortDateToJSDate(res[1])
+          ];
+        } else {
+          this.modelDate = res || null;
+        }
       })
     );
   }
@@ -47,7 +61,14 @@ export class ShortdatePickerComponent
   }
 
   onDateChange() {
-    this.control.setValue(this.utils.convertJSDateToShortDate(this.modelDate));
+    if (this.range) {
+      this.control.setValue([
+        this.utils.convertJSDateToShortDate(this.modelDate[0]),
+        this.utils.convertJSDateToShortDate(this.modelDate[1])
+      ])
+    } else {
+      this.control.setValue(this.utils.convertJSDateToShortDate(this.modelDate));
+    }
     this.control.markAsDirty();
   }
 

--- a/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.ts
+++ b/src/app/shared/components/ds-forms/shortdate-picker/shortdate-picker.component.ts
@@ -35,10 +35,12 @@ export class ShortdatePickerComponent
 
   initializeControl() {
     if (this.range) {
-      this.modelDate = [
-        this.utils.convertShortDateToJSDate(this.control.value[0] || null),
-        this.utils.convertShortDateToJSDate(this.control.value[1] || null)
-      ];
+      if (this.control.value) {
+        this.modelDate = [
+          this.utils.convertShortDateToJSDate(this.control.value[0] || null),
+          this.utils.convertShortDateToJSDate(this.control.value[1] || null)
+        ];
+      }
     } else {
       this.modelDate = this.control.value || null;
     }

--- a/src/app/shared/components/metrics/chart-metric/chart-metric-plugins.ts
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric-plugins.ts
@@ -16,6 +16,11 @@ const barHighlightColumn = {
       scales: { x, y },
     } = chart;
 
+    // check if data is decimated
+    if (x.ticks?.length !== x.max + 1) {
+      return;
+    }
+
     if (tooltip._active[0]) {
       const index = tooltip._active[0].index;
 
@@ -30,7 +35,7 @@ const barHighlightColumn = {
 
 export class ChartPlugins {
   // List non-global plugins here. These plugins have to be manually added to each chart that uses them.
-  public readonly barHighlightColumnPlugin = barHighlightColumn;
+  public static readonly barHighlightColumnPlugin = barHighlightColumn;
 }
 
 export function registerGlobalChartPlugins() {

--- a/src/app/shared/components/metrics/chart-metric/chart-metric.component.spec.ts
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric.component.spec.ts
@@ -22,16 +22,6 @@ describe('ChartMetricComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('handles observables', async () => {
-    component.labels = ['label1', 'label2'];
-    component.datasets = ['dataset1', 'dataset2'];
-    component.options = { option1: 'option1' };
-    component.plugins = ['plugin1'];
-    component['_isChartReady'].next(true);
-    await fixture.isStable();
-    fixture.detectChanges();
-  });
-
   it('awaits all async calls before building chart', async () => {
     expect(buildSpy).not.toHaveBeenCalled();
     component.type = 'bar';

--- a/src/app/shared/components/metrics/chart-metric/chart-metric.component.ts
+++ b/src/app/shared/components/metrics/chart-metric/chart-metric.component.ts
@@ -73,6 +73,14 @@ export class ChartMetricComponent implements OnDestroy, AfterViewInit {
         options: this._options?.value || {},
         plugins: this._plugins?.value || [],
       });
+    } else {
+      this.chart.data = {
+        labels: this._labels?.value || [],
+        datasets: this._datasets?.value || [],
+      };
+      this.chart.options = this._options?.value || {};
+      this.chart.plugins = this._plugins?.value || [];
+      this.chart.update();
     }
   }
 

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -18,6 +18,7 @@ export class Constants {
     PASS_CHECK_IN_LIST_EVENT: 'pass-check-in-list-event',
     MODIFIERS: 'modifiers',
     METRICS_FILTERS_PARAMS: 'metrics-filters-params',
+    CURRENT_METRICS: 'metrics-cache',
     PASS_LOOKUP_PARK_SELECT_CACHE: 'passLookupParkSelectCache',
     PASS_LOOKUP_FACILITY_SELECT_CACHE: 'passLookupFacilitySelectCache',
   };

--- a/src/app/shared/utils/count-to.directive.ts
+++ b/src/app/shared/utils/count-to.directive.ts
@@ -37,7 +37,7 @@ export class CountToDirective implements OnDestroy, OnInit {
     this._jitter.next(jitter);
   }
 
-  private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+  private ngUnsubscribe: Subject<void> = new Subject<void>();
   // default count
   private readonly _count = new BehaviorSubject(0);
   private readonly _oldCount = new BehaviorSubject(0);
@@ -104,6 +104,7 @@ export class CountToDirective implements OnDestroy, OnInit {
   }
 
   ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
   }
 }

--- a/src/app/shared/utils/count-to.directive.ts
+++ b/src/app/shared/utils/count-to.directive.ts
@@ -22,12 +22,12 @@ import {
 } from 'rxjs';
 
 @Directive({
-    // eslint-disable-next-line
+  // eslint-disable-next-line
   selector: '[countTo]',
 })
 export class CountToDirective implements OnDestroy, OnInit {
   @Input('countTo') set count(count: number) {
-    this._oldCount.next(this._count.value);
+    this._oldCount.next(this._count.value || 0);
     this._count.next(count);
   }
   @Input() set duration(duration: number) {
@@ -76,7 +76,7 @@ export class CountToDirective implements OnDestroy, OnInit {
   constructor(
     private readonly elementRef: ElementRef,
     private readonly renderer: Renderer2
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.displayCurrentCount();
@@ -91,9 +91,10 @@ export class CountToDirective implements OnDestroy, OnInit {
     this._currentValue
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((currentValue) => {
-        const displayValue = currentValue
-          ? formatNumber(currentValue, 'en-US')
-          : '-';
+        let displayValue = formatNumber(currentValue, 'en-US');
+        if (isNaN(currentValue)) {
+          displayValue = '-';
+        }
         this.renderer.setProperty(
           this.elementRef.nativeElement,
           'innerHTML',
@@ -103,6 +104,6 @@ export class CountToDirective implements OnDestroy, OnInit {
   }
 
   ngOnDestroy(): void {
-      this.ngUnsubscribe.complete();
+    this.ngUnsubscribe.complete();
   }
 }

--- a/src/app/shared/utils/mock-data.ts
+++ b/src/app/shared/utils/mock-data.ts
@@ -269,4 +269,134 @@ export class MockData {
     'cancelled': 300,
     'expired': 4000
   }
+
+  public static readonly mockMetrics1 = {
+      lastUpdated: '2023-03-28T10:09:37.713-07:00',
+      sk: '2023-01-31',
+      cancelled: 0,
+      capacities: {
+          AM: {
+              baseCapacity: 14,
+              capacityModifier: 0,
+              checkedIn: 5,
+              passStatuses: {
+                  active: 5,
+                  reserved: 3,
+                  expired: 1,
+                  cancelled: 4,
+              },
+              availablePasses: 5,
+              overbooked: 0
+          },
+          PM: {
+              baseCapacity: 10,
+              capacityModifier: 0,
+              checkedIn: 0,
+              passStatuses: {},
+              availablePasses: 10,
+              overbooked: 0
+          }
+      },
+      pk: 'metrics::MOC1::Mock Facility 1',
+      totalPasses: 9,
+      fullyBooked: false,
+      hourlyData: [
+          {
+              hour: 0,
+              checkedIn: 0
+          },
+          {
+              hour: 1,
+              checkedIn: 0
+          },
+          {
+              hour: 2,
+              checkedIn: 0
+          },
+          {
+              hour: 3,
+              checkedIn: 0
+          },
+          {
+              hour: 4,
+              checkedIn: 0
+          },
+          {
+              hour: 5,
+              checkedIn: 0
+          },
+          {
+              hour: 6,
+              checkedIn: 0
+          },
+          {
+              hour: 7,
+              checkedIn: 0
+          },
+          {
+              hour: 8,
+              checkedIn: 0
+          },
+          {
+              hour: 9,
+              checkedIn: 5
+          },
+          {
+              hour: 10,
+              checkedIn: 0
+          },
+          {
+              hour: 11,
+              checkedIn: 0
+          },
+          {
+              hour: 12,
+              checkedIn: 0
+          },
+          {
+              hour: 13,
+              checkedIn: 0
+          },
+          {
+              hour: 14,
+              checkedIn: 0
+          },
+          {
+              hour: 15,
+              checkedIn: 0
+          },
+          {
+              hour: 16,
+              checkedIn: 0
+          },
+          {
+              hour: 17,
+              checkedIn: 0
+          },
+          {
+              hour: 18,
+              checkedIn: 0
+          },
+          {
+              hour: 19,
+              checkedIn: 0
+          },
+          {
+              hour: 20,
+              checkedIn: 0
+          },
+          {
+              hour: 21,
+              checkedIn: 0
+          },
+          {
+              hour: 22,
+              checkedIn: 0
+          },
+          {
+              hour: 23,
+              checkedIn: 0
+          }
+      ]
+  }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-1020

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1020

### Description:
Requires https://github.com/bcgov/parks-reso-api/pull/252.

## IMPORTANT:
There are now two very similar instances of metrics related services in the codebase:

 - Instances of `metric` refer to implementations for the OLD metrics services & systems.
 - Instances of `metrics` <- NOTE THE plural 's' refer to implementations of the NEW metrics system. 

References to the old implementations remain in the code base as their functionality is important for future tickets (BRS-1049) but should be phased out in a future ticket. 

Front end changes to go along with the new API changes for continuous metrics monitoring. Statistics for this iteration include Pass Breakdown by Status and Pass Activity by Day. Date range length is limited to a 1 year period maximum. 

Resolver will preselect 'All Parks' on first navigation to the metrics page, but user must select a date or date range to do an initial search of metrics. If a refinement of params is done on the page, the params will be saved if the user goes to a different part of the site and then comes back. 

Pass Activity By Day will only render if a single facility has been selected.

Pass Breakdown by status will only render if passes were found. 

The old `Export` button that generated a .csv of all passes in the system has been removed - it is expected that this button and its functionality will be reintroduced in https://bcparksdigital.atlassian.net/browse/BRS-1049 as the new metrics system is better suited to generate this csv. The functionality for the old export remains in the codebase as reference but should probably be removed as part of BRS-1049.