### PR TITLE
BRS-1130 adding park name to exported capacity report

### DIFF
--- a/src/app/services/metrics.service.ts
+++ b/src/app/services/metrics.service.ts
@@ -111,33 +111,36 @@ export class MetricsService {
       if (!metricsList || !metricsList.length) {
         throw 'No data to be exported.';
       }
+      // Get park name - we can assume all metrics in the list are from the same park as the capacity data in this report is not very useful otherwise.
+      // This may have to change later.
+      const parkName = this.dataService.getItemValue(Constants.dataIds.PARK_AND_FACILITY_LIST)[park].name;
       const dateInterval = this.utils.createShortDateInterval(dateRange[0], dateRange[1]);
       let content = [['Park', 'Facility', 'Date', 'Status', 'AM base capacity', 'AM capacity modifier', 'AM total passes', 'AM booked passes', 'AM cancellations', 'PM base capacity', 'PM capacity modifier', 'PM total passes', 'PM booked passes', 'PM cancellations', 'All-Day base capacity', 'All-Day capacity modifier', 'All-Day total passes', 'All-Day booked passes', 'All-Day cancellations']];
       for (const date of dateInterval) {
         let metric = metricsList.find((item) => item.sk === date);
-        content.push([park, facility, date,
-          '', // TODO: update metrics to include open/closed status
-          metric?.capacities?.AM?.baseCapacity ?? '',
-          metric?.capacities?.AM?.capacityModifier ?? '',
+        content.push([parkName, facility, date,
+          'N/A', // TODO: update metrics to include open/closed status
+          metric?.capacities?.AM?.baseCapacity ?? 'N/A',
+          metric?.capacities?.AM?.capacityModifier ?? 'N/A',
           isNaN(metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier) ?
-            '' : metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier,
+            'N/A' : metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier,
           isNaN(metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier - metric?.capacities?.AM?.availablePasses) ?
-            '' : metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier - metric?.capacities?.AM?.availablePasses,
-          metric?.capacities?.AM?.passStatuses?.cancelled ?? '',
-          metric?.capacities?.PM?.baseCapacity ?? '',
-          metric?.capacities?.PM?.capacityModifier ?? '',
+            'N/A' : metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier - metric?.capacities?.AM?.availablePasses,
+          metric?.capacities?.AM?.passStatuses?.cancelled ?? 'N/A',
+          metric?.capacities?.PM?.baseCapacity ?? 'N/A',
+          metric?.capacities?.PM?.capacityModifier ?? 'N/A',
           isNaN(metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier) ?
-            '' : metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier,
+            'N/A' : metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier,
           isNaN(metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier - metric?.capacities?.PM?.availablePasses) ?
-            '' : metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier - metric?.capacities?.PM?.availablePasses,
-          metric?.capacities?.PM?.passStatuses?.cancelled ?? '',
-          metric?.capacities?.DAY?.baseCapacity ?? '',
-          metric?.capacities?.DAY?.capacityModifier ?? '',
+            'N/A' : metric?.capacities?.PM?.baseCapacity + metric?.capacities?.PM?.capacityModifier - metric?.capacities?.PM?.availablePasses,
+          metric?.capacities?.PM?.passStatuses?.cancelled ?? 'N/A',
+          metric?.capacities?.DAY?.baseCapacity ?? 'N/A',
+          metric?.capacities?.DAY?.capacityModifier ?? 'N/A',
           isNaN(metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier) ?
-            '' : metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier,
+            'N/A' : metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier,
           isNaN(metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier - metric?.capacities?.DAY?.availablePasses) ?
-            '' : metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier - metric?.capacities?.DAY?.availablePasses,
-          metric?.capacities?.DAY?.passStatuses?.cancelled ?? '',
+            'N/A' : metric?.capacities?.DAY?.baseCapacity + metric?.capacities?.DAY?.capacityModifier - metric?.capacities?.DAY?.availablePasses,
+          metric?.capacities?.DAY?.passStatuses?.cancelled ?? 'N/A',
         ]);
       }
       let csvData = '';


### PR DESCRIPTION
### Jira Ticket:
BRS-1130

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1130

### Description:
Capacity report exporter uses the metrics filter params in `dataService` to determine which metrics to pull. These params only contain the park `orcs` so we must do an additional `dataService` match to get the park name for the exporter.

Also empty cells have been replaced with 'N/A' as per the old report.