### PR TITLE
BRS-1092 use key instead of value for CURRENT_FACILITY/CURRENT_PARK

### DIFF
--- a/src/app/parks-management/facility-details/facility-details.component.spec.ts
+++ b/src/app/parks-management/facility-details/facility-details.component.spec.ts
@@ -15,7 +15,7 @@ describe('FacilityDetailsComponent', () => {
   let testFacility = MockData.mockFacility_1;
 
   let testSubject = new BehaviorSubject(testFacility);
-  let mockFacilityKey = {pk: testFacility.pk, sk: testFacility.sk};
+  let mockFacilityKey = { pk: testFacility.pk, sk: testFacility.sk };
 
   let fakeDataService = {
     watchItem: () => {

--- a/src/app/parks-management/facility-details/facility-details.component.spec.ts
+++ b/src/app/parks-management/facility-details/facility-details.component.spec.ts
@@ -6,6 +6,7 @@ import { DataService } from 'src/app/services/data.service';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { FacilityDetailsComponent } from './facility-details.component';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('FacilityDetailsComponent', () => {
   let component: FacilityDetailsComponent;
@@ -14,12 +15,22 @@ describe('FacilityDetailsComponent', () => {
   let testFacility = MockData.mockFacility_1;
 
   let testSubject = new BehaviorSubject(testFacility);
+  let mockFacilityKey = {pk: testFacility.pk, sk: testFacility.sk};
 
   let fakeDataService = {
     watchItem: () => {
       return testSubject;
     },
   };
+
+  let mockFacilityService = {
+    getCachedFacility: (facilityKey) => {
+      if (facilityKey.pk === mockFacilityKey.pk && facilityKey.sk === mockFacilityKey.sk) {
+        return testFacility;
+      }
+      return null;
+    }
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -29,6 +40,7 @@ describe('FacilityDetailsComponent', () => {
         HttpHandler,
         ConfigService,
         { provide: DataService, useValue: fakeDataService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/facility-details/facility-details.component.ts
+++ b/src/app/parks-management/facility-details/facility-details.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ConfigService } from 'src/app/services/config.service';
 import { DataService } from 'src/app/services/data.service';
+import { FacilityService } from 'src/app/services/facility.service';
 import { Constants } from 'src/app/shared/utils/constants';
 import { Utils } from 'src/app/shared/utils/utils';
 
@@ -17,14 +18,15 @@ export class FacilityDetailsComponent implements OnDestroy {
 
   constructor(
     protected dataService: DataService,
-    protected configService: ConfigService
+    protected configService: ConfigService,
+    protected facilityService: FacilityService
   ) {
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
           }
         })
     );

--- a/src/app/parks-management/facility-details/passes-filter/passes-filter.component.spec.ts
+++ b/src/app/parks-management/facility-details/passes-filter/passes-filter.component.spec.ts
@@ -9,6 +9,7 @@ import { DataService } from 'src/app/services/data.service';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { PassesFilterComponent } from './passes-filter.component';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('PassesFilterComponent', () => {
   let component: PassesFilterComponent;
@@ -16,10 +17,20 @@ describe('PassesFilterComponent', () => {
   let location: Location;
 
   let mockFacility = MockData.mockFacility_1;
+  let mockFacilityKey = { pk: mockFacility.pk, sk: mockFacility.sk}
 
   let mockPartialPassFilter = MockData.mockPartialPassFilters_1;
 
   let mockSubject = new BehaviorSubject(mockFacility);
+
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacilityKey.pk && key.sk === mockFacilityKey.sk) {
+        return mockFacility;
+      }
+      return null;
+    },
+  };
 
   let mockDataService = {
     watchItem: () => {
@@ -42,6 +53,7 @@ describe('PassesFilterComponent', () => {
         HttpHandler,
         ConfigService,
         { provide: DataService, useValue: mockDataService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/facility-details/passes-filter/passes-filter.component.ts
+++ b/src/app/parks-management/facility-details/passes-filter/passes-filter.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DataService } from 'src/app/services/data.service';
+import { FacilityService } from 'src/app/services/facility.service';
 import { LoadingService } from 'src/app/services/loading.service';
 import { PassService } from 'src/app/services/pass.service';
 import { ReservationService } from 'src/app/services/reservation.service';
@@ -36,7 +37,8 @@ export class PassesFilterComponent extends BaseFormComponent {
     protected changeDetector: ChangeDetectorRef,
     protected passService: PassService,
     protected reservationService: ReservationService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private facilityService: FacilityService
   ) {
     super(
       formBuilder,
@@ -48,10 +50,10 @@ export class PassesFilterComponent extends BaseFormComponent {
 
     this.subscriptions.add(
       this.dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
             this.bookingTimesList = this.getBookingTimesList();
           }
         })

--- a/src/app/parks-management/facility-details/passes-utility-buttons/passes-utility-buttons.component.spec.ts
+++ b/src/app/parks-management/facility-details/passes-utility-buttons/passes-utility-buttons.component.spec.ts
@@ -9,6 +9,7 @@ import { MockData } from 'src/app/shared/utils/mock-data';
 import { PassUtils } from 'src/app/utils/pass-utils';
 
 import { PassesUtilityButtonsComponent } from './passes-utility-buttons.component';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('PassesUtilityButtonsComponent', () => {
   let component: PassesUtilityButtonsComponent;
@@ -23,12 +24,21 @@ describe('PassesUtilityButtonsComponent', () => {
 
   let mockPassList = new BehaviorSubject([mockPass1, mockPass2]);
 
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacility.pk && key.sk === mockFacility.sk) {
+        return mockFacility;
+      }
+      return null;
+    }
+  }
+
   let mockDataService = {
     watchItem: (id) => {
       if (id === Constants.dataIds.PASSES_LIST) {
         return mockPassList;
       }
-      if (id === Constants.dataIds.CURRENT_FACILITY) {
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
         return new BehaviorSubject(mockFacility);
       }
       if (id === Constants.dataIds.PASS_SEARCH_PARAMS) {
@@ -53,6 +63,7 @@ describe('PassesUtilityButtonsComponent', () => {
         ConfigService,
         { provide: KeycloakService, useValue: mockKeyCloakService },
         { provide: DataService, useValue: mockDataService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/facility-details/passes-utility-buttons/passes-utility-buttons.component.ts
+++ b/src/app/parks-management/facility-details/passes-utility-buttons/passes-utility-buttons.component.ts
@@ -8,6 +8,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { PassUtils } from 'src/app/utils/pass-utils';
 import { DateTime } from 'luxon';
 import { KeycloakService } from 'src/app/services/keycloak.service';
+import { FacilityService } from 'src/app/services/facility.service';
 
 @Component({
   selector: 'app-passes-utility-buttons',
@@ -27,7 +28,8 @@ export class PassesUtilityButtonsComponent implements OnDestroy {
     protected toastService: ToastService,
     protected dataService: DataService,
     protected keyCloakService: KeycloakService,
-    protected passService: PassService
+    protected passService: PassService,
+    protected facilityService: FacilityService
   ) {
     this.subscriptions.add(
       dataService.watchItem(Constants.dataIds.PASSES_LIST).subscribe((res) => {
@@ -37,10 +39,10 @@ export class PassesUtilityButtonsComponent implements OnDestroy {
 
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
             this.parkSk = this.facility.pk.split('::')[1];
           }
         })

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.spec.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.spec.ts
@@ -10,20 +10,48 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { FacilityEditFormComponent } from './facility-edit-form.component';
+import { ParkService } from 'src/app/services/park.service';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('FacilityEditFormComponent', () => {
   let component: FacilityEditFormComponent;
   let fixture: ComponentFixture<FacilityEditFormComponent>;
 
   let mockFacility1 = MockData.mockFacility_1;
+  let mockFacility1Key = { pk: mockFacility1.pk, sk: mockFacility1.sk };
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk };
+
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    }
+  }
+
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacility1Key.pk && key.sk === mockFacility1Key.sk) {
+        return mockFacility1;
+      }
+      return null;
+    },
+    postFacility: (facility) => {
+      return null;
+    },
+    putFacility: (facility) => {
+      return null;
+    }
+  }
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_FACILITY) {
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
         return new BehaviorSubject([mockFacility1]);
       }
-      if (id === Constants.dataIds.CURRENT_PARK) {
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
         return new BehaviorSubject([mockPark]);
       }
       return null;
@@ -46,6 +74,8 @@ describe('FacilityEditFormComponent', () => {
         { provide: ConfigService, useValue: mockConfigService },
         BsModalService,
         { provide: DataService, useValue: mockDataService },
+        { provide: ParkService, useValue: mockParkService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 
@@ -108,6 +138,7 @@ describe('FacilityEditFormComponent', () => {
   });
 
   it('submits formatted facility 1 to facilityService', async () => {
+    component.park = mockPark;
     const putSpy = spyOn(component['facilityService'], 'putFacility');
     const postSpy = spyOn(component['facilityService'], 'postFacility');
     component.submitFacilityChanges(mockFacility1);
@@ -121,11 +152,37 @@ describe('FacilityAddFormComponent', () => {
   let fixture: ComponentFixture<FacilityEditFormComponent>;
 
   let mockFacility2 = MockData.mockFacility_2;
+  let mockFacility2Key = { pk: mockFacility2.pk, sk: mockFacility2.sk };
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk };
+
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    }
+  }
+
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacility2Key.pk && key.sk === mockFacility2Key.sk) {
+        return mockFacility2;
+      }
+      return null;
+    },
+    postFacility: (facility) => {
+      return null;
+    },
+    putFacility: (facility) => {
+      return null;
+    }
+  }
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_PARK) {
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
         return new BehaviorSubject([mockPark]);
       }
       return new BehaviorSubject(false);
@@ -148,6 +205,8 @@ describe('FacilityAddFormComponent', () => {
         { provide: ConfigService, useValue: mockConfigService },
         BsModalService,
         { provide: DataService, useValue: mockDataService },
+        { provide: ParkService, useValue: mockParkService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 
@@ -176,6 +235,7 @@ describe('FacilityAddFormComponent', () => {
   });
 
   it('submits formatted facility 2 to facilityService', async () => {
+    component.park = mockPark;
     const putSpy = spyOn(component['facilityService'], 'putFacility');
     const postSpy = spyOn(component['facilityService'], 'postFacility');
     component.submitFacilityChanges(mockFacility2);

--- a/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit-form/facility-edit-form.component.ts
@@ -18,6 +18,7 @@ import { ConfigService } from 'src/app/services/config.service';
 import { DataService } from 'src/app/services/data.service';
 import { FacilityService } from 'src/app/services/facility.service';
 import { LoadingService } from 'src/app/services/loading.service';
+import { ParkService } from 'src/app/services/park.service';
 import { BaseFormComponent } from 'src/app/shared/components/ds-forms/base-form/base-form.component';
 import { modalSchema } from 'src/app/shared/components/modal/modal.component';
 import { Constants } from 'src/app/shared/utils/constants';
@@ -51,6 +52,7 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     protected loadingService: LoadingService,
     protected changeDetector: ChangeDetectorRef,
     private facilityService: FacilityService,
+    private parkService: ParkService,
     private route: ActivatedRoute,
     private modalService: BsModalService,
     private configService: ConfigService
@@ -58,10 +60,10 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     super(formBuilder, router, dataService, loadingService, changeDetector);
     this.subscriptions.add(
       this.dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
             this.data = this.facility;
             this.setForm();
           } else {
@@ -70,9 +72,9 @@ export class FacilityEditFormComponent extends BaseFormComponent {
         })
     );
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.CURRENT_PARK).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.CURRENT_PARK_KEY).subscribe((res) => {
         if (res) {
-          this.park = res;
+          this.park = this.parkService.getCachedPark(res);
         }
       })
     );
@@ -98,69 +100,69 @@ export class FacilityEditFormComponent extends BaseFormComponent {
     // Create booking days subform:
     let bookableDaysFormGroup = new UntypedFormGroup({
       Monday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['1'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['1'] : true
       ),
       Tuesday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['2'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['2'] : true
       ),
       Wednesday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['3'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['3'] : true
       ),
       Thursday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['4'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['4'] : true
       ),
       Friday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['5'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['5'] : true
       ),
       Saturday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['6'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['6'] : true
       ),
       Sunday: new UntypedFormControl(
-        this.data.bookingDays ? this.data.bookingDays['7'] : true
+        this.data?.bookingDays ? this.data?.bookingDays['7'] : true
       ),
     });
     // Create booking time capacities subform
     let bookingTimesFormGroup = new UntypedFormGroup({
-      AM: new UntypedFormControl(this.data.bookingTimes?.AM ? true : false),
-      PM: new UntypedFormControl(this.data.bookingTimes?.PM ? true : false),
-      DAY: new UntypedFormControl(this.data.bookingTimes?.DAY ? true : false),
+      AM: new UntypedFormControl(this.data?.bookingTimes?.AM ? true : false),
+      PM: new UntypedFormControl(this.data?.bookingTimes?.PM ? true : false),
+      DAY: new UntypedFormControl(this.data?.bookingTimes?.DAY ? true : false),
       capacityAM: new UntypedFormControl(
-        this.data.bookingTimes?.AM?.max || null
+        this.data?.bookingTimes?.AM?.max || null
       ),
       capacityPM: new UntypedFormControl(
-        this.data.bookingTimes?.PM?.max || null
+        this.data?.bookingTimes?.PM?.max || null
       ),
       capacityDAY: new UntypedFormControl(
-        this.data.bookingTimes?.DAY?.max || null
+        this.data?.bookingTimes?.DAY?.max || null
       ),
     });
     // Create base form
     this.form = new UntypedFormGroup({
       facilityStatus: new UntypedFormControl(
-        this.data.status?.state === 'open' ? true : false
+        this.data?.status?.state === 'open' ? true : false
       ),
       facilityClosureReason: new UntypedFormControl(
-        this.data.status?.stateReason || null
+        this.data?.status?.stateReason || null
       ),
       facilityVisibility: new UntypedFormControl(
-        this.data.visible ? this.data.visible : false
+        this.data?.visible ? this.data?.visible : false
       ),
       facilityQRCode: new UntypedFormControl(
-        this.data.qrcode ? this.data.qrcode : false
+        this.data?.qrcode ? this.data?.qrcode : false
       ),
-      facilityName: new UntypedFormControl(this.data.name, Validators.required),
-      facilityType: new UntypedFormControl(this.data.type, Validators.required),
+      facilityName: new UntypedFormControl(this.data?.name, Validators.required),
+      facilityType: new UntypedFormControl(this.data?.type, Validators.required),
       facilityBookingOpeningHour: new UntypedFormControl({
-        hour: this.data.bookingOpeningHour || 7,
+        hour: this.data?.bookingOpeningHour || 7,
         minute: 0,
         second: 0,
       } as NgbTimeStruct),
       facilityBookingDaysAhead: new UntypedFormControl(
-        this.data.bookingDaysAhead
+        this.data?.bookingDaysAhead
       ),
       facilityBookingDaysRichText: new UntypedFormControl(
         this.data
-          ? this.data.bookingDaysRichText
+          ? this.data?.bookingDaysRichText
           : this.defaultBookingDaysRichText
       ),
       facilityBookingDays: bookableDaysFormGroup,

--- a/src/app/parks-management/facility-edit/facility-edit.component.spec.ts
+++ b/src/app/parks-management/facility-edit/facility-edit.component.spec.ts
@@ -15,9 +15,9 @@ describe('FacilityEditComponent', () => {
   let fixture: ComponentFixture<FacilityEditComponent>;
 
   let mockFacility = MockData.mockFacility_1;
-  let mockFacilityKey = {pk: mockFacility.pk, sk: mockFacility.sk};
+  let mockFacilityKey = { pk: mockFacility.pk, sk: mockFacility.sk };
   let mockPark = MockData.mockPark_1;
-  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk};
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk };
 
   let mockDataService = {
     watchItem: (id) => {

--- a/src/app/parks-management/facility-edit/facility-edit.component.spec.ts
+++ b/src/app/parks-management/facility-edit/facility-edit.component.spec.ts
@@ -7,25 +7,47 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { FacilityEditComponent } from './facility-edit.component';
+import { ParkService } from 'src/app/services/park.service';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('FacilityEditComponent', () => {
   let component: FacilityEditComponent;
   let fixture: ComponentFixture<FacilityEditComponent>;
 
   let mockFacility = MockData.mockFacility_1;
+  let mockFacilityKey = {pk: mockFacility.pk, sk: mockFacility.sk};
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk};
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_FACILITY) {
-        return new BehaviorSubject(mockFacility);
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
+        return new BehaviorSubject(mockFacilityKey);
       }
-      if (id === Constants.dataIds.CURRENT_PARK) {
-        return new BehaviorSubject(mockPark);
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
+        return new BehaviorSubject(mockParkKey);
       }
       return null;
     },
   };
+
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    }
+  }
+
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacilityKey.pk && key.sk === mockFacilityKey.sk) {
+        return mockFacility;
+      }
+      return null;
+    }
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -35,6 +57,8 @@ describe('FacilityEditComponent', () => {
         HttpHandler,
         ConfigService,
         { provide: DataService, useValue: mockDataService },
+        { provide: ParkService, useValue: mockParkService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/facility-edit/facility-edit.component.ts
+++ b/src/app/parks-management/facility-edit/facility-edit.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
+import { FacilityService } from 'src/app/services/facility.service';
 import { ModifierService } from 'src/app/services/modifier.service';
+import { ParkService } from 'src/app/services/park.service';
 import { Constants } from 'src/app/shared/utils/constants';
 import { Utils } from 'src/app/shared/utils/utils';
 
@@ -19,23 +21,24 @@ export class FacilityEditComponent implements OnDestroy {
 
   constructor(
     protected dataService: DataService,
-    protected modifierService: ModifierService
+    protected modifierService: ModifierService,
+    protected facilityService: FacilityService,
+    protected parkService: ParkService
   ) {
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
             this.updateModifiers();
           }
         })
     );
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.CURRENT_PARK).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.CURRENT_PARK_KEY).subscribe((res) => {
         if (res) {
-          this.park = res;
-          this.updateModifiers();
+          this.park = this.parkService.getCachedPark(res);
         }
       })
     );

--- a/src/app/parks-management/modifiers-form/modifiers-form.component.spec.ts
+++ b/src/app/parks-management/modifiers-form/modifiers-form.component.spec.ts
@@ -8,20 +8,42 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { ModifiersFormComponent } from './modifiers-form.component';
+import { ParkService } from 'src/app/services/park.service';
+import { FacilityService } from 'src/app/services/facility.service';
 
 describe('ModifiersFormComponent', () => {
   let component: ModifiersFormComponent;
   let fixture: ComponentFixture<ModifiersFormComponent>;
 
   let mockFacility = MockData.mockFacility_1;
+  let mockFacilityKey = { pk: mockFacility.pk, sk: mockFacility.sk };
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk };
+
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    }
+  }
+
+  let mockFacilityService = {
+    getCachedFacility: (key) => {
+      if (key.pk === mockFacilityKey.pk && key.sk === mockFacilityKey.sk) {
+        return mockFacility;
+      }
+      return null;
+    },
+  }
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_FACILITY) {
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
         return new BehaviorSubject(mockFacility);
       }
-      if (id === Constants.dataIds.CURRENT_PARK) {
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
         return new BehaviorSubject(mockPark);
       }
       return new BehaviorSubject(null);
@@ -37,6 +59,8 @@ describe('ModifiersFormComponent', () => {
         HttpHandler,
         ConfigService,
         { provide: DataService, useValue: mockDataService },
+        { provide: ParkService, useValue: mockParkService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/modifiers-form/modifiers-form.component.ts
+++ b/src/app/parks-management/modifiers-form/modifiers-form.component.ts
@@ -7,8 +7,10 @@ import {
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
+import { FacilityService } from 'src/app/services/facility.service';
 import { LoadingService } from 'src/app/services/loading.service';
 import { ModifierService } from 'src/app/services/modifier.service';
+import { ParkService } from 'src/app/services/park.service';
 import { BaseFormComponent } from 'src/app/shared/components/ds-forms/base-form/base-form.component';
 import { Constants } from 'src/app/shared/utils/constants';
 
@@ -35,24 +37,26 @@ export class ModifiersFormComponent
     protected dataService: DataService,
     protected loadingService: LoadingService,
     protected changeDetector: ChangeDetectorRef,
-    private modifierService: ModifierService
+    private modifierService: ModifierService,
+    private facilityService: FacilityService,
+    private parkService: ParkService,
   ) {
     super(formBuilder, router, dataService, loadingService, changeDetector);
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY)
+        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
         .subscribe((res) => {
           if (res) {
-            this.facility = res;
+            this.facility = this.facilityService.getCachedFacility(res);
             this.setBookingTimes();
             this.setForm();
           }
         })
     );
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.CURRENT_PARK).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.CURRENT_PARK_KEY).subscribe((res) => {
         if (res) {
-          this.park = res;
+          this.park = this.parkService.getCachedPark(res);
           this.setForm();
         }
       })

--- a/src/app/parks-management/park-details/park-details.component.spec.ts
+++ b/src/app/parks-management/park-details/park-details.component.spec.ts
@@ -13,19 +13,20 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { MockData } from 'src/app/shared/utils/mock-data';
 import { ParkDetailsComponent } from './park-details.component';
 import { By } from '@angular/platform-browser';
+import { ParkService } from 'src/app/services/park.service';
 
 describe('ParkDetailsComponent', () => {
   let component: ParkDetailsComponent;
   let fixture: ComponentFixture<ParkDetailsComponent>;
 
   let mockFacility1 = MockData.mockFacility_1;
-  let mockFacility2 = MockData.mockFacility_2;
 
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk};
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_PARK) {
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
         return new BehaviorSubject(mockPark);
       }
       // TODO: fix this to reflect data accurately
@@ -36,7 +37,16 @@ describe('ParkDetailsComponent', () => {
     },
   };
 
-  let mockKeyCloakService = {
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    },
+  };
+
+    let mockKeyCloakService = {
     isAllowed: (perm) => {
       if (perm === 'add-facility') {
         return true;
@@ -57,6 +67,7 @@ describe('ParkDetailsComponent', () => {
         RouterTestingModule,
         { provide: DataService, useValue: mockDataService },
         { provide: KeycloakService, useValue: mockKeyCloakService },
+        { provide: ParkService, useValue: mockParkService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/park-details/park-details.component.spec.ts
+++ b/src/app/parks-management/park-details/park-details.component.spec.ts
@@ -22,7 +22,7 @@ describe('ParkDetailsComponent', () => {
   let mockFacility1 = MockData.mockFacility_1;
 
   let mockPark = MockData.mockPark_1;
-  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk};
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk };
 
   let mockDataService = {
     watchItem: (id) => {

--- a/src/app/parks-management/park-details/park-details.component.ts
+++ b/src/app/parks-management/park-details/park-details.component.ts
@@ -7,6 +7,7 @@ import { tableSchema } from 'src/app/shared/components/table/table.component';
 import { TableButtonComponent } from 'src/app/shared/components/table/table-components/table-button/table-button.component';
 import { KeycloakService } from 'src/app/services/keycloak.service';
 import { TextWithIconsComponent } from 'src/app/shared/components/text-with-icons/text-with-icons.component';
+import { ParkService } from 'src/app/services/park.service';
 
 @Component({
   selector: 'app-park-details',
@@ -24,12 +25,13 @@ export class ParkDetailsComponent implements OnInit, OnDestroy {
     protected dataService: DataService,
     private router: Router,
     private route: ActivatedRoute,
-    protected keycloakService: KeycloakService
+    protected keycloakService: KeycloakService,
+    private parkService: ParkService,
   ) {
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.CURRENT_PARK).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.CURRENT_PARK_KEY).subscribe((res) => {
         if (res) {
-          this.park = res;
+          this.park = this.parkService.getCachedPark(res);
         }
       })
     );

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
@@ -18,7 +18,7 @@ describe('ParkEditFormComponent', () => {
   let fixture: ComponentFixture<ParkEditFormComponent>;
 
   let mockPark = MockData.mockPark_1;
-  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk}
+  let mockParkKey = { pk: mockPark.pk, sk: mockPark.sk }
 
   // Have to format the object how the API is expecting it.
   let mockSubmission = {

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
@@ -11,12 +11,14 @@ import { Constants } from 'src/app/shared/utils/constants';
 import { MockData } from 'src/app/shared/utils/mock-data';
 
 import { ParkEditFormComponent } from './park-edit-form.component';
+import { ParkService } from 'src/app/services/park.service';
 
 describe('ParkEditFormComponent', () => {
   let component: ParkEditFormComponent;
   let fixture: ComponentFixture<ParkEditFormComponent>;
 
   let mockPark = MockData.mockPark_1;
+  let mockParkKey = {pk: mockPark.pk, sk: mockPark.sk}
 
   // Have to format the object how the API is expecting it.
   let mockSubmission = {
@@ -32,10 +34,22 @@ describe('ParkEditFormComponent', () => {
     visible: mockPark.visible,
   };
 
+  let mockParkService = {
+    getCachedPark: (key) => {
+      if (key.pk === mockParkKey.pk && key.sk === mockParkKey.sk) {
+        return mockPark;
+      }
+      return null;
+    },
+    putPark: (park) => {
+      return park;
+    }
+  }
+
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_PARK) {
-        return new BehaviorSubject(mockPark);
+      if (id === Constants.dataIds.CURRENT_PARK_KEY) {
+        return new BehaviorSubject(mockParkKey);
       }
       return new BehaviorSubject(null);
     },
@@ -51,6 +65,7 @@ describe('ParkEditFormComponent', () => {
         ConfigService,
         BsModalService,
         { provide: DataService, useValue: mockDataService },
+        { provide: ParkService, useValue: mockParkService },
       ],
     }).compileComponents();
 

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.ts
@@ -48,9 +48,9 @@ export class ParkEditFormComponent extends BaseFormComponent {
   ) {
     super(formBuilder, router, dataService, loadingService, changeDetector);
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.CURRENT_PARK).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.CURRENT_PARK_KEY).subscribe((res) => {
         if (res) {
-          this.park = res;
+          this.park = this.parkService.getCachedPark(res);
           this.data = this.park;
           this.setForm();
         }

--- a/src/app/resolvers/facility-add.resolver.spec.ts
+++ b/src/app/resolvers/facility-add.resolver.spec.ts
@@ -19,7 +19,7 @@ describe('FacilityAddResolver', () => {
     const setItemSpy = spyOn(resolver['dataService'], 'setItemValue');
     await resolver.resolve();
     expect(setItemSpy).toHaveBeenCalledOnceWith(
-      Constants.dataIds.CURRENT_FACILITY,
+      Constants.dataIds.CURRENT_FACILITY_KEY,
       null
     );
   });

--- a/src/app/resolvers/facility-add.resolver.ts
+++ b/src/app/resolvers/facility-add.resolver.ts
@@ -9,6 +9,6 @@ import { Constants } from '../shared/utils/constants';
 export class FacilityAddResolver implements Resolve<void> {
   constructor(protected dataService: DataService) {}
   resolve() {
-    this.dataService.setItemValue(Constants.dataIds.CURRENT_FACILITY, null);
+    this.dataService.setItemValue(Constants.dataIds.CURRENT_FACILITY_KEY, null);
   }
 }

--- a/src/app/resolvers/facility-details.resolver.spec.ts
+++ b/src/app/resolvers/facility-details.resolver.spec.ts
@@ -22,7 +22,7 @@ describe('FacilityDetailsResolver', () => {
   };
 
   let mockFacility1 = MockData.mockFacility_1;
-  let mockFacility1Key = {pk: mockFacility1.pk, sk: mockFacility1.sk};
+  let mockFacility1Key = { pk: mockFacility1.pk, sk: mockFacility1.sk };
 
   let mockDataService = {
     watchItem: (id) => {

--- a/src/app/resolvers/facility-details.resolver.spec.ts
+++ b/src/app/resolvers/facility-details.resolver.spec.ts
@@ -9,6 +9,7 @@ import { Constants } from '../shared/utils/constants';
 import { MockData } from '../shared/utils/mock-data';
 
 import { FacilityDetailsResolver } from './facility-details.resolver';
+import { FacilityService } from '../services/facility.service';
 
 describe('FacilityDetailsResolver', () => {
   let resolver: FacilityDetailsResolver;
@@ -21,13 +22,23 @@ describe('FacilityDetailsResolver', () => {
   };
 
   let mockFacility1 = MockData.mockFacility_1;
+  let mockFacility1Key = {pk: mockFacility1.pk, sk: mockFacility1.sk};
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.CURRENT_FACILITY) {
-        return new BehaviorSubject(mockFacility1);
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
+        return new BehaviorSubject(mockFacility1Key);
       }
       return new BehaviorSubject(null);
+    },
+  };
+
+  let mockFacilityService = {
+    getCachedFacility: (facilityKey) => {
+      if (facilityKey === mockFacility1Key) {
+        return mockFacility1;
+      }
+      return null;
     },
   };
 
@@ -51,6 +62,7 @@ describe('FacilityDetailsResolver', () => {
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         { provide: DataService, useValue: mockDataService },
         { provide: PassService, useValue: mockPassService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     });
     resolver = TestBed.inject(FacilityDetailsResolver);

--- a/src/app/resolvers/facility-details.resolver.ts
+++ b/src/app/resolvers/facility-details.resolver.ts
@@ -20,11 +20,11 @@ export class FacilityDetailsResolver implements Resolve<void> {
   async resolve(route: ActivatedRouteSnapshot) {
     const terminate = new Subject();
     this.dataService
-      .watchItem(Constants.dataIds.CURRENT_FACILITY)
+      .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
       .pipe(takeUntil(terminate))
       .subscribe(async (res) => {
         if (res) {
-          const facility = res;
+          const facility = this.facilityService.getCachedFacility(res);
           if (facility) {
             const filteredParams = await this.passService.setParamsFromUrl(
               facility,

--- a/src/app/resolvers/facility.resolver.spec.ts
+++ b/src/app/resolvers/facility.resolver.spec.ts
@@ -32,6 +32,9 @@ describe('FacilityResolver', () => {
       return new BehaviorSubject(null);
     },
     setItemValue: (id, obj) => {
+      if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {
+        return obj;
+      }
       return null;
     },
   };
@@ -58,8 +61,11 @@ describe('FacilityResolver', () => {
     const setItemSpy = spyOn(resolver['dataService'], 'setItemValue');
     await resolver.resolve(route.snapshot);
     expect(setItemSpy).toHaveBeenCalledOnceWith(
-      Constants.dataIds.CURRENT_FACILITY,
-      mockParkFacility1.MOC1.facilities['Mock Facility 1']
+      Constants.dataIds.CURRENT_FACILITY_KEY,
+      {
+        pk: 'facility::MOC1',
+        sk: 'Mock Facility 1',
+      }
     );
   });
 });

--- a/src/app/resolvers/facility.resolver.ts
+++ b/src/app/resolvers/facility.resolver.ts
@@ -25,8 +25,11 @@ export class FacilityResolver implements Resolve<void> {
       .subscribe((res) => {
         if (res) {
           this.dataService.setItemValue(
-            Constants.dataIds.CURRENT_FACILITY,
-            res[route.params['parkId']].facilities[route.params['facilityId']]
+            Constants.dataIds.CURRENT_FACILITY_KEY,
+            {
+              pk: `facility::${route.params['parkId']}`,
+              sk: route.params['facilityId']
+            }
           );
           terminate.next(null);
         }

--- a/src/app/resolvers/park.resolver.spec.ts
+++ b/src/app/resolvers/park.resolver.spec.ts
@@ -59,7 +59,7 @@ describe('ParkResolver', () => {
     expect(setItemSpy).toHaveBeenCalledTimes(2);
     expect(setItemSpy).toHaveBeenCalledWith(
       Constants.dataIds.CURRENT_PARK_KEY,
-      {pk: mockParkFacility1.MOC1.pk, sk: mockParkFacility1.MOC1.sk}
+      { pk: mockParkFacility1.MOC1.pk, sk: mockParkFacility1.MOC1.sk }
     );
     expect(setItemSpy).toHaveBeenCalledWith(
       Constants.dataIds.FACILITIES_LIST,

--- a/src/app/resolvers/park.resolver.spec.ts
+++ b/src/app/resolvers/park.resolver.spec.ts
@@ -58,8 +58,8 @@ describe('ParkResolver', () => {
     await resolver.resolve(route.snapshot);
     expect(setItemSpy).toHaveBeenCalledTimes(2);
     expect(setItemSpy).toHaveBeenCalledWith(
-      Constants.dataIds.CURRENT_PARK,
-      mockParkFacility1.MOC1
+      Constants.dataIds.CURRENT_PARK_KEY,
+      {pk: mockParkFacility1.MOC1.pk, sk: mockParkFacility1.MOC1.sk}
     );
     expect(setItemSpy).toHaveBeenCalledWith(
       Constants.dataIds.FACILITIES_LIST,

--- a/src/app/resolvers/park.resolver.ts
+++ b/src/app/resolvers/park.resolver.ts
@@ -8,7 +8,7 @@ import { Constants } from '../shared/utils/constants';
   providedIn: 'root',
 })
 export class ParkResolver implements Resolve<void> {
-  constructor(protected dataService: DataService) {}
+  constructor(protected dataService: DataService) { }
   resolve(route: ActivatedRouteSnapshot) {
     const terminate = new Subject();
     this.dataService
@@ -17,8 +17,8 @@ export class ParkResolver implements Resolve<void> {
       .subscribe((res) => {
         if (res) {
           this.dataService.setItemValue(
-            Constants.dataIds.CURRENT_PARK,
-            res[route.params['parkId']]
+            Constants.dataIds.CURRENT_PARK_KEY,
+            { pk: 'park', sk: route.params['parkId']}
           );
           this.dataService.setItemValue(
             Constants.dataIds.FACILITIES_LIST,

--- a/src/app/services/breadcrumb.service.ts
+++ b/src/app/services/breadcrumb.service.ts
@@ -10,6 +10,7 @@ import { filter } from 'rxjs/operators';
 import { Breadcrumb } from '../models/breadcrumb.model';
 import { Constants } from '../shared/utils/constants';
 import { DataService } from './data.service';
+import { ParkService } from './park.service';
 
 @Injectable({
   providedIn: 'root',
@@ -23,16 +24,16 @@ export class BreadcrumbService {
   // Observable exposing the breadcrumb hierarchy
   readonly breadcrumbs = this._breadcrumbs.asObservable();
 
-  constructor(private router: Router, private dataService: DataService) {
+  constructor(private router: Router, private dataService: DataService, private parkService: ParkService) {
     // Initial seed
     this.setBreadcrum();
 
     this.subscriptions.add(
       this.dataService
-        .watchItem(Constants.dataIds.CURRENT_PARK)
+        .watchItem(Constants.dataIds.CURRENT_PARK_KEY)
         .subscribe((res) => {
           if (res) {
-            this.park = res;
+            this.park = this.parkService.getCachedPark(res);
             this.setBreadcrum();
           }
         })

--- a/src/app/services/facility.service.spec.ts
+++ b/src/app/services/facility.service.spec.ts
@@ -16,9 +16,12 @@ import { Constants } from '../shared/utils/constants';
 describe('FacilityService', () => {
   let service: FacilityService;
 
+  let mockFacility1 = MockData.mockFacility_1;
+  let mockFacility2 = MockData.mockFacility_2;
+
   let parkFacilitiesRes = new BehaviorSubject([
-    MockData.mockFacility_1,
-    MockData.mockFacility_2,
+    mockFacility1,
+    mockFacility2,
   ]);
 
   let specificFacilityRes = new BehaviorSubject([MockData.mockFacility_1]);
@@ -143,8 +146,8 @@ describe('FacilityService', () => {
       park: 'Mock Park 1',
     });
     expect(setDataSpy).toHaveBeenCalledOnceWith(
-      Constants.dataIds.CURRENT_FACILITY,
-      specificFacilityRes.value[0]
+      Constants.dataIds.CURRENT_FACILITY_KEY,
+      { pk: mockFacility1.pk, sk: mockFacility1.sk }
     );
     expect(unloadingSpy).toHaveBeenCalledTimes(1);
   });
@@ -203,5 +206,25 @@ describe('FacilityService', () => {
         'Facility Service'
       )
     );
+  });
+
+  it('gets facility by key', async () => {
+    spyOn(service['dataService'], 'getItemValue').and.callFake((dataId) => {
+      if (dataId === Constants.dataIds.PARK_AND_FACILITY_LIST) {
+        return {
+          MOC1: {
+            facilities: {
+              "Mock Facility 1": mockFacility1
+            }
+          }
+        }
+      }
+      if (dataId === Constants.dataIds.CURRENT_FACILITY_KEY) {
+        return { pk: mockFacility1.pk, sk: mockFacility1.sk }
+      }
+      return null;
+    });
+    expect(service.getCachedFacility({ pk: mockFacility1.pk, sk: mockFacility1.sk })).toEqual(mockFacility1);
+    expect(service.getCurrentFacility()).toEqual(mockFacility1);
   });
 });

--- a/src/app/services/facility.service.ts
+++ b/src/app/services/facility.service.ts
@@ -40,7 +40,7 @@ export class FacilityService {
         this.dataService.setItemValue(dataTag, res);
       } else if (facilitySk && parkSk) {
         // We are getting a single facility.
-        dataTag = Constants.dataIds.CURRENT_FACILITY;
+        dataTag = Constants.dataIds.CURRENT_FACILITY_KEY;
         this.loadingService.addToFetchList(dataTag);
         errorSubject = 'facility';
         this.loggerService.debug(`Facility GET: ${parkSk} ${facilitySk}`);
@@ -52,8 +52,8 @@ export class FacilityService {
             })
           )
         )[0];
-        if (!skipCache) {
-          this.dataService.setItemValue(dataTag, res);
+        if (!skipCache && res?.pk && res?.sk) {
+          this.dataService.setItemValue(dataTag, {pk: res.pk, sk: res.sk});
         }
       }
     } catch (e) {
@@ -103,10 +103,10 @@ export class FacilityService {
           if (updateParkAndFacilityCache) {
             this.dataService.updateParkAndFacilityCache(res);
           }
-          if (updateCurrentParkCache) {
+          if (updateCurrentParkCache && res?.pk && res?.sk) {
             this.dataService.setItemValue(
-              Constants.dataIds.CURRENT_FACILITY,
-              res
+              Constants.dataIds.CURRENT_FACILITY_KEY,
+              { pk: res.pk, sk: res.sk }
             );
           }
         } catch (error) {
@@ -194,5 +194,20 @@ export class FacilityService {
   validateFacilityObject(obj) {
     // TODO: write this function
     return true;
+  }
+
+  // Get current facility, key is stored in DataService.
+  getCurrentFacility() {
+    const key = this.dataService.getItemValue(Constants.dataIds.CURRENT_FACILITY_KEY);
+    if (key) {
+      return this.getCachedFacility(key);
+    }
+    return null;
+  }
+
+  // Get facility from cache using provided key.
+  getCachedFacility(key) {
+    const orcs = key?.pk.split('::')[1];
+    return this.dataService.getItemValue(Constants.dataIds.PARK_AND_FACILITY_LIST)[orcs].facilities[key?.sk] || null;
   }
 }

--- a/src/app/services/facility.service.ts
+++ b/src/app/services/facility.service.ts
@@ -20,7 +20,7 @@ export class FacilityService {
     private loggerService: LoggerService,
     private apiService: ApiService,
     private loadingService: LoadingService
-  ) {}
+  ) { }
   public utils = new Utils();
 
   async fetchData(parkSk = null, facilitySk = null, skipCache = false) {
@@ -53,7 +53,7 @@ export class FacilityService {
           )
         )[0];
         if (!skipCache && res?.pk && res?.sk) {
-          this.dataService.setItemValue(dataTag, {pk: res.pk, sk: res.sk});
+          this.dataService.setItemValue(dataTag, { pk: res.pk, sk: res.sk });
         }
       }
     } catch (e) {
@@ -152,7 +152,7 @@ export class FacilityService {
           throw 'Must provide a park.';
         }
         // Build the cachedObject for the front-end.
-        const cachedObject = Object.assign({ pk: `facility::${parkSk}`, sk: obj.name}, obj);
+        const cachedObject = Object.assign({ pk: `facility::${parkSk}`, sk: obj.name }, obj);
         delete obj.pk;
         delete obj.sk;
         obj.parkOrcs = parkSk;

--- a/src/app/services/park.service.spec.ts
+++ b/src/app/services/park.service.spec.ts
@@ -133,8 +133,8 @@ describe('ParkService', () => {
     expect(loggerDebugSpy).toHaveBeenCalledTimes(1);
     expect(apiGetSpy).toHaveBeenCalledOnceWith('park', { park: 'Mock Park 1' });
     expect(setDataSpy).toHaveBeenCalledOnceWith(
-      Constants.dataIds.CURRENT_PARK,
-      mockParkRes.value[0]
+      Constants.dataIds.CURRENT_PARK_KEY,
+      {pk: 'park', sk: 'MOC1'}
     );
     expect(unloadingSpy).toHaveBeenCalledTimes(1);
   });
@@ -172,5 +172,21 @@ describe('ParkService', () => {
       new EventObject(EventKeywords.ERROR, 'Error: put error', 'Park Service')
     );
     expect(unloadingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('gets park by key', async () => {
+    spyOn(service['dataService'], 'getItemValue').and.callFake((dataId) => {
+      if (dataId === Constants.dataIds.PARK_AND_FACILITY_LIST) {
+        return {
+          MOC1: mockParkObj
+        }
+      }
+      if (dataId === Constants.dataIds.CURRENT_PARK_KEY) {
+        return { pk: mockParkObj.pk, sk: mockParkObj.sk }
+      }
+      return null;
+    });
+    expect(service.getCachedPark({pk: mockParkObj.pk, sk: mockParkObj.sk})).toEqual(mockParkObj);
+    expect(service.getCurrentPark()).toEqual(mockParkObj);
   });
 });

--- a/src/app/services/park.service.spec.ts
+++ b/src/app/services/park.service.spec.ts
@@ -134,7 +134,7 @@ describe('ParkService', () => {
     expect(apiGetSpy).toHaveBeenCalledOnceWith('park', { park: 'Mock Park 1' });
     expect(setDataSpy).toHaveBeenCalledOnceWith(
       Constants.dataIds.CURRENT_PARK_KEY,
-      {pk: 'park', sk: 'MOC1'}
+      { pk: 'park', sk: 'MOC1' }
     );
     expect(unloadingSpy).toHaveBeenCalledTimes(1);
   });
@@ -186,7 +186,7 @@ describe('ParkService', () => {
       }
       return null;
     });
-    expect(service.getCachedPark({pk: mockParkObj.pk, sk: mockParkObj.sk})).toEqual(mockParkObj);
+    expect(service.getCachedPark({ pk: mockParkObj.pk, sk: mockParkObj.sk })).toEqual(mockParkObj);
     expect(service.getCurrentPark()).toEqual(mockParkObj);
   });
 });

--- a/src/app/services/reservation.service.spec.ts
+++ b/src/app/services/reservation.service.spec.ts
@@ -9,6 +9,7 @@ import { LoadingService } from './loading.service';
 import { BehaviorSubject } from 'rxjs';
 import { ApiService } from './api.service';
 import { EventKeywords, EventObject } from './event.service';
+import { FacilityService } from './facility.service';
 
 describe('ReservationService', () => {
   let service: ReservationService;
@@ -16,6 +17,12 @@ describe('ReservationService', () => {
   let mockReservationGetRes = new BehaviorSubject([
     MockData.mockReservationObj_1,
   ]);
+
+  let mockFacilityService = {
+    getCurrentFacility: () => {
+      return MockData.mockFacility_1;
+    },
+  }
 
   let mockApiService = {
     get: (id, params) => {
@@ -65,6 +72,7 @@ describe('ReservationService', () => {
         { provide: LoggerService, useValue: mockLoggerService },
         { provide: LoadingService, useValue: mockLoadingService },
         { provide: ApiService, useValue: mockApiService },
+        { provide: FacilityService, useValue: mockFacilityService },
       ],
     });
     service = TestBed.inject(ReservationService);
@@ -146,6 +154,7 @@ describe('ReservationService', () => {
   });
 
   it('sets the capacity bar if reservation object does not exist', async () => {
+    const curFacilitySpy = spyOn(service['facilityService'], 'getCurrentFacility').and.callThrough();
     await service.fetchData('noResObj', 'Mock Facility 1', '2022-12-29', 'AM');
     expect(loadingSpy).toHaveBeenCalledTimes(1);
     expect(loggerDebugSpy).toHaveBeenCalledTimes(1);
@@ -159,9 +168,7 @@ describe('ReservationService', () => {
       []
     );
     // gets current facility instead
-    expect(getDataSpy).toHaveBeenCalledOnceWith(
-      Constants.dataIds.CURRENT_FACILITY
-    );
+    expect(curFacilitySpy).toHaveBeenCalledTimes(1);
     expect(setDataSpy).toHaveBeenCalledWith(
       Constants.dataIds.CURRENT_CAPACITY_BAR_OBJECT,
       {

--- a/src/app/services/reservation.service.ts
+++ b/src/app/services/reservation.service.ts
@@ -7,6 +7,7 @@ import { EventKeywords, EventObject, EventService } from './event.service';
 import { LoadingService } from './loading.service';
 import { LoggerService } from './logger.service';
 import { ToastService, ToastTypes } from './toast.service';
+import { FacilityService } from './facility.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +19,8 @@ export class ReservationService {
     private toastService: ToastService,
     private loggerService: LoggerService,
     private apiService: ApiService,
-    private loadingService: LoadingService
+    private loadingService: LoadingService,
+    private facilityService: FacilityService
   ) {}
 
   async fetchData(parkSk, facilitySk, resDate = null, selectedPassType = null) {
@@ -48,9 +50,7 @@ export class ReservationService {
           this.setCapacityBar(res[0], selectedPassType);
         } else {
           // No res Object. Use facility cap
-          const facility = this.dataService.getItemValue(
-            Constants.dataIds.CURRENT_FACILITY
-          );
+          const facility = this.facilityService.getCurrentFacility();
           this.dataService.setItemValue(
             Constants.dataIds.CURRENT_CAPACITY_BAR_OBJECT,
             {

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -2,9 +2,9 @@ export class Constants {
   public static readonly dataIds = {
     PARK_AND_FACILITY_LIST: 'parksFaciltiyList',
     PARKS_LIST: 'parksList',
-    CURRENT_PARK: 'currentPark',
+    CURRENT_PARK_KEY: 'currentParkKey',
     FACILITIES_LIST: 'facilitiesList',
-    CURRENT_FACILITY: 'currentFacility',
+    CURRENT_FACILITY_KEY: 'currentFacilityKey',
     PASSES_LIST: 'passesList',
     PASS_SEARCH_PARAMS: 'passSearchParams',
     PASS_LAST_EVALUATED_KEY: 'passLastEvaluatedKey',


### PR DESCRIPTION
### Jira Ticket:
BRS-1092

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1092

### Description:
In `dataService`, CURRENT_FACILITY and CURRENT_PARK dataIds used to contain the whole facility/park object, duplicating the data that already exists in PARK_AND_FACILITY_LIST. 

CURRENT_FACILITY and CURRENT PARK now only contain the primary key for the object, which can then be used to parse PARK_AND_FACILITY_LIST to get the same value as before (so the data is only stored in one place in local cache). 

Some functionality has been added to the park and facility services to simplify the retrieval of data from the cache. 

These data ids were used in a lot of places which has lead to the artificial ballooning of this change size. Most of the changes across the files touched are the same, and their `.spec` files have also been updated accordingly. 

Focus on the resolvers and park/facility services to get a better idea of the changes. 