### PR TITLE
BRS-1089 & BRS-1017: updates to pass list

### DIFF
--- a/src/app/pass-management/pass-check-in-list/pass-check-in-list.component.spec.ts
+++ b/src/app/pass-management/pass-check-in-list/pass-check-in-list.component.spec.ts
@@ -94,6 +94,7 @@ describe('PassLookupComponent', () => {
 
   it('should check in pass', async () => {
     const checkedOutPass = { ...MockData.mockPass_1 };
+    delete checkedOutPass.checkedIn
     checkedOutPass.passStatus = 'active';
     component.passes = [{ ...MockData.mockPass_1 }];
     await component.checkIn(checkedOutPass);

--- a/src/app/pass-management/pass-management-home/pass-management-home.component.html
+++ b/src/app/pass-management/pass-management-home/pass-management-home.component.html
@@ -4,7 +4,7 @@
 <div class="pt-3 container-fluid">
   <div class="pt-md-5 container container-fluid">
     <div class="row">
-      <div class="col" *ngFor="let card of cardConfig">
+      <div class="col-md-6 col-12 mb-3" *ngFor="let card of cardConfig">
         <app-nav-card [cardHeader]="card.cardHeader" [cardTitle]="card.cardTitle" [cardText]="card.cardText"
           [navigation]="card.navigation" [relative]="true"></app-nav-card>
       </div>

--- a/src/app/pass-management/pass-management.module.ts
+++ b/src/app/pass-management/pass-management.module.ts
@@ -23,6 +23,7 @@ import { DsFormsModule } from '../shared/components/ds-forms/ds-forms.module';
 import { TableModule } from '../shared/components/table/table.module';
 import { PassesFilterFieldsComponent } from './pass-search/passes-filter/passes-filter-fields/passes-filter-fields.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
+import { PassAccordionComponent } from './pass-search/passes-list/pass-accordion/pass-accordion.component';
 
 @NgModule({
   declarations: [
@@ -37,7 +38,8 @@ import { BsModalService } from 'ngx-bootstrap/modal';
     PassesFilterComponent,
     PassesListComponent,
     PassesUtilityButtonsComponent,
-    PassesFilterFieldsComponent
+    PassesFilterFieldsComponent,
+    PassAccordionComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/pass-management/pass-search/pass-search.component.html
+++ b/src/app/pass-management/pass-search/pass-search.component.html
@@ -15,6 +15,11 @@
       </div>
     </div>
   </div>
+  <div class="m-4">
+    <h2><span *ngIf="currentPark">{{currentPark}}: </span><span *ngIf="currentFacility">{{currentFacility}}</span><span
+        *ngIf="currentPassType"> ({{currentPassType}})</span></h2>
+    <h3 *ngIf="currentDate">{{currentDate | date: 'mediumDate'}}</h3>
+  </div>
   <div class="mx-4 mt-4">
     <div class="row">
       <div class="col-12">
@@ -22,7 +27,7 @@
       </div>
     </div>
   </div>
-  <div class="mt-4">
+  <div class="m-4">
     <app-passes-list></app-passes-list>
   </div>
 </section>

--- a/src/app/pass-management/pass-search/pass-search.component.spec.ts
+++ b/src/app/pass-management/pass-search/pass-search.component.spec.ts
@@ -38,18 +38,4 @@ describe('PassSearchComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('gets opening hour text', async () => {
-    component.facility = mockFacility;
-    expect(component.bookingOpeningHourText).toEqual('7 AM');
-    component.facility = null;
-    expect(component.bookingOpeningHourText).toEqual('8 AM');
-  });
-
-  it('gets booking days ahead text', async () => {
-    component.facility = mockFacility;
-    expect(component.bookingDaysAheadText).toEqual('2 days');
-    component.facility = null;
-    expect(component.bookingDaysAheadText).toEqual('Same Day');
-  
-  });
 });

--- a/src/app/pass-management/pass-search/pass-search.component.ts
+++ b/src/app/pass-management/pass-search/pass-search.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 import { ConfigService } from 'src/app/services/config.service';
 import { DataService } from 'src/app/services/data.service';
 import { FacilityService } from 'src/app/services/facility.service';
+import { ParkService } from 'src/app/services/park.service';
 import { Constants } from 'src/app/shared/utils/constants';
 import { Utils } from 'src/app/shared/utils/utils';
 
@@ -13,59 +14,30 @@ import { Utils } from 'src/app/shared/utils/utils';
 })
 export class PassSearchComponent {
   private subscriptions = new Subscription();
-  public facility;
   public Utils = new Utils();
+  public currentFacility;
+  public currentPark;
+  public currentDate;
+  public currentPassType;
 
   constructor(
     protected dataService: DataService,
     protected configService: ConfigService,
-    protected facilityService: FacilityService
+    protected facilityService: FacilityService,
+    protected parkService: ParkService
   ) {
     this.subscriptions.add(
       dataService
-        .watchItem(Constants.dataIds.CURRENT_FACILITY_KEY)
+        .watchItem(Constants.dataIds.PASS_SEARCH_PARAMS)
         .subscribe((res) => {
           if (res) {
-            this.facility = this.facilityService.getCachedFacility(res);
+            this.currentFacility = res.facilityName;
+            this.currentPark = this.parkService.getCachedPark({pk: 'park', sk: res.park})?.name;
+            this.currentDate = res.date;
+            this.currentPassType = res.passType;
           }
         })
     );
-  }
-
-  get bookingOpeningHourText() {
-    const facilityBookingOpeningHour = this.facility
-      ? this.facility.bookingOpeningHour
-      : null;
-    const advanceBookingHour =
-      facilityBookingOpeningHour ||
-      parseInt(this.configService.config['ADVANCE_BOOKING_HOUR'], 10);
-    const { hour, amPm } = this.Utils.convert24hTo12hTime(advanceBookingHour);
-
-    if (hour && amPm) {
-      return `${hour} ${amPm}`;
-    }
-    return '';
-  }
-
-  get bookingDaysAheadText() {
-    let advanceBookingDays = this.facility
-      ? this.facility.bookingDaysAhead
-      : null;
-    if (advanceBookingDays !== 0 && !advanceBookingDays) {
-      advanceBookingDays = parseInt(
-        this.configService.config['ADVANCE_BOOKING_LIMIT'],
-        10
-      );
-    }
-
-    if (advanceBookingDays === 0) {
-      return 'Same Day';
-    }
-    if (advanceBookingDays === 1) {
-      return '1 day';
-    }
-
-    return `${advanceBookingDays} days`;
   }
 
   ngOnDestroy(): void {

--- a/src/app/pass-management/pass-search/passes-capacity-bar/passes-capacity-bar.component.html
+++ b/src/app/pass-management/pass-search/passes-capacity-bar/passes-capacity-bar.component.html
@@ -20,15 +20,17 @@
           <small><i class="bi bi-exclamation-triangle-fill"></i> {{ data.overbooked }} passes overbooked</small>
         </div>
       </div>
-      <div *ngIf="data.modifier > 0 || data.modifier < 0" class="text-muted">
-        <small>Modifier applied</small>
+      <div *ngIf="data.reserved !== null">
+        <small>{{data?.checkInCount ? data.checkInCount : '0'}} pass{{data?.checkInCount === 1 ? '' : 'es'}} checked in</small>
       </div>
     </strong>
+    <div *ngIf="data.modifier > 0 || data.modifier < 0" class="text-muted">
+      <small>Modifier applied</small>
+    </div>
   </label>
-  <ngb-progressbar
-    [showValue]="true"
-    type="{{ data.style }}"
-    [value]="data.capPercent"
-    height="1.5rem"
-  ></ngb-progressbar>
+  <div *ngIf="data.reserved !== null">
+    <ngb-progressbar class="capacity-bar-top" [showValue]="true" type="{{ data.style }}" [value]="data.capPercent"
+    height="1.5rem"></ngb-progressbar>
+    <ngb-progressbar class="capacity-bar-bottom" [showValue]="false" type="success" [value]="data.checkInCount" [max]="data.capacity" height="1.0rem"></ngb-progressbar>
+  </div>
 </div>

--- a/src/app/pass-management/pass-search/passes-capacity-bar/passes-capacity-bar.component.scss
+++ b/src/app/pass-management/pass-search/passes-capacity-bar/passes-capacity-bar.component.scss
@@ -1,0 +1,10 @@
+.capacity-bar-top {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.capacity-bar-bottom {
+  border-top: 1px solid #ccc;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}

--- a/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.html
+++ b/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.html
@@ -1,0 +1,62 @@
+<section>
+  <div *ngIf="isHeader && getCurrentScreenSize() > 2" class="d-flex row text-nowrap border border-2 border-white">
+    <div class="fw-bold px-3 pb-1 accordion-header overflow-hidden {{col?.columnClasses}}"
+      *ngFor="let col of getHeaderColumns()" [attr.id]="col?.id">
+      <div *ngIf="col?.displayHeader">
+        {{col?.displayHeader}}
+      </div>
+    </div>
+    <div class="col-auto" id="cancelButton">
+      <!-- Empty col for cancel button header -->
+    </div>
+    <hr class="mb-1">
+  </div>
+  <div *ngIf="!isHeader" class="d-flex row mt-2 text-nowrap justify-content-between">
+    <div class="col">
+      <div class="row d-flex border border-2 accordion-item align-items-center"
+        [ngClass]="pass?.isOverbooked ? 'border-danger' : 'border-secondary'">
+        <div *ngFor="let col of getHeaderColumns()" class="p-3 overflow-hidden {{col?.columnClasses}}"
+          [attr.id]="col?.id" [ngClass]="[pass?.isOverbooked ? 'overbooked text-danger' : '']" data-bs-toggle="collapse"
+          [attr.data-bs-target]="'#p' + pass?.sk">
+          <div *ngIf="col?.display">
+            {{col?.display(pass)}}
+          </div>
+          <div *ngIf="col?.template">
+            <ng-container [ngTemplateOutlet]="col.template" [ngTemplateOutletContext]="{pass: pass}">
+            </ng-container>
+          </div>
+          <div *ngIf="!col?.display && !col?.template">
+            {{pass[col?.key]}}
+          </div>
+        </div>
+      </div>
+      <!-- Dropdown template for when you click on the pass row -->
+      <!-- You can't have an id tag that starts with a digit -->
+      <div *ngIf="!isHeader" [attr.id]="'p'+pass?.sk" class="collapse">
+        <div class="d-flex row overflow-hidden accordion-item" data-bs-toggle="collapse"
+          [attr.data-bs-target]="'#p' + pass?.sk">
+          <div class="bg-light">
+            <div class="row">
+              <div class="col-xs-12 col-sm-auto p-3" *ngFor="let col of getDropdownColumns()">
+                <strong>{{col?.displayHeader}}</strong>
+                <div *ngIf="col?.display && !col?.template">
+                  {{col?.display(pass)}}
+                </div>
+                <div *ngIf="col?.template">
+                  <ng-container [ngTemplateOutlet]="col.template" [ngTemplateOutletContext]="{pass: pass}">
+                  </ng-container>
+                </div>
+                <div *ngIf="!col?.display && !col?.template">
+                  {{pass[col?.key]}}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-auto pt-2 border border-2 border-white" id="cancelButton">
+      <ng-container [ngTemplateOutlet]="cancelTemplate" [ngTemplateOutletContext]="{pass: pass}"></ng-container>
+    </div>
+  </div>
+</section>

--- a/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.scss
+++ b/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.scss
@@ -1,3 +1,3 @@
-.filter-button {
+.accordion-item {
   cursor: pointer;
 }

--- a/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.spec.ts
+++ b/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PassAccordionComponent } from './pass-accordion.component';
+
+describe('PassAccordionComponent', () => {
+  let component: PassAccordionComponent;
+  let fixture: ComponentFixture<PassAccordionComponent>;
+
+  let mockRowSchema = [
+    {
+      id: 'passId',
+      dropdown: 0,
+      key: 'registrationNumber' // value of pass object associated with column
+    },
+    {
+      id: 'numberOfGuests',
+      dropdown: 4,
+      key: 'numberOfGuests'
+    },
+    {
+      id: 'date',
+      dropdown: 0,
+      key: 'shortPassDate'
+    },
+    {
+      id: 'email',
+      dropdown: 3,
+      key: 'email'
+    },
+    {
+      id: 'name',
+      dropdown: 5,
+      key: 'lastName',
+    },
+    {
+      id: 'status',
+      dropdown: 2,
+      key: 'passStatus',
+    },
+    {
+      id: 'checkedIn',
+      dropdown: 2,
+      key: 'checkedIn',
+    },
+    {
+      id: 'isOverbooked',
+      dropdown: 3,
+      key: 'isOverbooked',
+    },
+    {
+      id: 'park',
+      dropdown: 7,
+      key: 'parkName',
+    },
+    {
+      id: 'facility',
+      dropdown: 7,
+      key: 'facilityName',
+    },
+    {
+      id: 'passType',
+      dropdown: 7,
+      key: 'type',
+    },
+    {
+      id: 'checkInTime',
+      dropdown: 7,
+      key: 'checkedInTime',
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PassAccordionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PassAccordionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('returns current screen size', async() => {
+    // breakpoints have added buffer to ensure breakage before actually breakpoint is reached
+    let widthSpy = spyOnProperty(window, 'innerWidth').and.returnValue(360); //mobile
+    expect(component.getCurrentScreenSize()).toEqual(0);
+    widthSpy.and.returnValue(600);
+    expect(component.getCurrentScreenSize()).toEqual(1);
+    widthSpy.and.returnValue(800);
+    expect(component.getCurrentScreenSize()).toEqual(2);
+    widthSpy.and.returnValue(850);
+    expect(component.getCurrentScreenSize()).toEqual(3);
+    widthSpy.and.returnValue(1050);
+    expect(component.getCurrentScreenSize()).toEqual(4);
+    widthSpy.and.returnValue(1300);
+    expect(component.getCurrentScreenSize()).toEqual(5);
+    widthSpy.and.returnValue(1500);
+    expect(component.getCurrentScreenSize()).toEqual(6);
+  });
+
+  it('sets accordion header and dropdown columns based on screensize', async() => {
+    component.rowSchema = mockRowSchema;
+    // header + dropdown column count should always be 12
+    let widthSpy = spyOn(component, 'getCurrentScreenSize').and.returnValue(0);
+    expect(component.getHeaderColumns().length).toEqual(2);
+    expect(component.getDropdownColumns().length).toEqual(10);
+    widthSpy.and.returnValue(6);
+    expect(component.getHeaderColumns().length).toEqual(8);
+    expect(component.getDropdownColumns().length).toEqual(4);
+  });
+});

--- a/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.ts
+++ b/src/app/pass-management/pass-search/passes-list/pass-accordion/pass-accordion.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'app-pass-accordion',
+  templateUrl: './pass-accordion.component.html',
+  styleUrls: ['./pass-accordion.component.scss']
+})
+
+export class PassAccordionComponent {
+  @Input() rowSchema: any[] = [];
+  @Input() dropDownSchema: any[] = [];
+  @Input() cancelTemplate: TemplateRef<any>;
+  @Input() pass: any;
+  @Input() isHeader: boolean = false;
+
+  getHeaderColumns() {
+    let columns = [];
+    let size = this.getCurrentScreenSize();
+    if (this.rowSchema) {
+      columns = this.rowSchema.filter(column => column?.dropdown <= size);
+    }
+    return columns;
+  }
+
+  getDropdownColumns() {
+    let columns = [];
+    let size = this.getCurrentScreenSize();
+    if (this.rowSchema) {
+      columns = this.rowSchema.filter(column => column?.dropdown > size);
+    }
+    return columns;
+  }
+
+  getCurrentScreenSize() {
+    // TODO: breakpoints are hard-coded. Can we load these straight from our bootstrap theme?
+    // Note: The breakpoints are slightly greater than the bootstrap set breakpoints to ensure no overflows
+    const buffer = 40;
+    const size = window.innerWidth;
+    if (size < 400 + buffer) {
+      return 0;
+    } else if (size < 576 + buffer) {
+      return 1;
+    } else if (size <= 768 + buffer) {
+      return 2;
+    } else if (size <= 992 + buffer) {
+      return 3;
+    } else if (size <= 1200 + buffer) {
+      return 4;
+    } else if (size <= 1400 + buffer) {
+      return 5;
+    } else {
+      return 6;
+    }
+  }
+}

--- a/src/app/pass-management/pass-search/passes-list/passes-list.component.html
+++ b/src/app/pass-management/pass-search/passes-list/passes-list.component.html
@@ -1,17 +1,103 @@
-<app-table
-  [tableSchema]="tableSchema"
-  [data]="tableRows"
-  [emptyTableMsg]="'No passes found.'"
-  [lastEvaluatedKey]="lastEvaluatedKey"
-  (loadMore)="loadMorePasses()"
-></app-table>
+<!-- checkedIn filters -->
+<div class="mb-5 mt-3 d-flex row">
+  <div *ngFor="let state of checkedInStates"
+    class="col-md-4 col-lg-auto border-bottom border-2 text-center filter-button"
+    [ngClass]="state?.value === checkedInState ? 'border-primary' : 'border-light'" (click)="changeCheckInState(state)">
+    <h4 class="px-4 mb-2 mt-3" [ngClass]="state?.value === checkedInState ? 'text-primary 
+    ' : 'text-muted'">
+      {{state?.label}}
+    </h4>
+  </div>
+</div>
 
-<!-- Here is where we store the templates for the specific modals shown from this page.  -->
-<!-- They are not rendered until clicked. -->
-<ng-template #passModalTemplate>
-  <app-modal [modal]="passModal"></app-modal>
-</ng-template>
+<!-- Results table -->
+<div id='pass-list'>
+  <div class="d-flex row">
+    <app-pass-accordion [rowSchema]="rowSchema" [isHeader]="true"></app-pass-accordion>
+  </div>
+  <div *ngIf="!loading">
+    <div *ngIf="!tableRows || tableRows?.length === 0"
+      class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-3 text-center">
+      No passes to display.
+    </div>
+    <div *ngFor="let pass of tableRows">
+      <app-pass-accordion [pass]="pass" [cancelTemplate]="passCancelButtonTemplate" [rowSchema]="rowSchema"
+        [dropDownSchema]="dropDownSchema"></app-pass-accordion>
+    </div>
+  </div>
+  <div *ngIf="loading"
+    class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-3 text-center">
+    <span class="spinner-border text-secondary"></span>
+  </div>
+</div>
 
+<!-- Load more button -->
+<div *ngIf="lastEvaluatedKey" class="d-flex flex-column h-100 align-items-center m-2">
+  <button class="btn btn-outline-secondary" (click)="loadMorePasses()">Load more</button>
+</div>
+
+<!-- Here is where we store the templates for elements within the accoridion table -->
+<!-- Cancel modal -->
 <ng-template #cancelModalTemplate>
   <app-modal [modal]="cancelModal"></app-modal>
+</ng-template>
+
+<!-- Pass status template -->
+<ng-template #passStatusTemplate let-pass="pass">
+  <div class="d-flex align-items-center overflow-hidden">
+    <div class="me-2">
+      <div *ngIf="pass?.passStatus === 'active'">
+        <i class="fs-3 bi bi-check-circle text-success"></i>
+      </div>
+      <div *ngIf="pass?.passStatus === 'reserved'">
+        <i class="fs-3 bi bi-clock text-warning"></i>
+      </div>
+      <div *ngIf="pass?.passStatus === 'expired'">
+        <i class="fs-3 bi bi-clock-history text-secondary pass-list-icon"></i>
+      </div>
+      <div *ngIf="pass?.passStatus === 'cancelled'">
+        <i class="fs-3 bi bi-x-circle text-danger pass-list-icon"></i>
+      </div>
+    </div>
+    <div>
+      {{pass?.passStatus}}
+    </div>
+  </div>
+</ng-template>
+
+<!-- Pass overbooked template -->
+<ng-template #passIsOverbookedTemplate let-pass="pass">
+  <div class="d-flex align-items-center overflow-hidden">
+    <div *ngIf="pass?.isOverbooked" class="d-flex">
+      <i class="text-danger fs-3 bi bi-exclamation-triangle-fill"></i>
+      <div class="d-flex d-md-none ms-2 text-danger">
+        Overbooked
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+<!-- Pass checked in template -->
+<ng-template #passCheckedInTemplate let-pass="pass">
+  <div class="d-flex align-items-center overflow-hidden">
+    <div>
+      <div *ngIf="!pass.checkedIn && pass?.passStatus !== 'active'">
+        <i class="fs-3 bi bi-circle text-secondary pass-list-icon"></i>
+      </div>
+      <div *ngIf="!pass.checkedIn && pass?.passStatus === 'active'">
+        <i class="fs-3 bi bi-circle text-success"></i>
+      </div>
+      <div *ngIf="pass.checkedIn">
+        <i class="fs-3 bi bi-check-circle-fill text-success"></i>
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+<!-- Cancellation button template -->
+<ng-template #passCancelButtonTemplate let-pass="pass">
+  <button class="btn btn-outline-danger" [disabled]="pass?.passStatus === 'cancelled' || pass?.passStatus === 'expired'"
+    (click)="displayCancelModal(pass)">
+    <i class="fs-3 bi bi-x-lg"></i>
+  </button>
 </ng-template>

--- a/src/app/pass-management/pass-search/passes-utility-buttons/passes-utility-buttons.component.spec.ts
+++ b/src/app/pass-management/pass-search/passes-utility-buttons/passes-utility-buttons.component.spec.ts
@@ -35,7 +35,7 @@ describe('PassesUtilityButtonsComponent', () => {
 
   let mockDataService = {
     watchItem: (id) => {
-      if (id === Constants.dataIds.PASSES_LIST) {
+      if (id === Constants.dataIds.FILTERED_PASSES_LIST) {
         return mockPassList;
       }
       if (id === Constants.dataIds.CURRENT_FACILITY_KEY) {

--- a/src/app/pass-management/pass-search/passes-utility-buttons/passes-utility-buttons.component.ts
+++ b/src/app/pass-management/pass-search/passes-utility-buttons/passes-utility-buttons.component.ts
@@ -32,7 +32,7 @@ export class PassesUtilityButtonsComponent implements OnDestroy {
     protected facilityService: FacilityService
   ) {
     this.subscriptions.add(
-      dataService.watchItem(Constants.dataIds.PASSES_LIST).subscribe((res) => {
+      dataService.watchItem(Constants.dataIds.FILTERED_PASSES_LIST).subscribe((res) => {
         this.passes = res;
       })
     );

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -23,7 +23,8 @@ export class DataService {
 
   // Append array data to existing dataService id
   appendItemValue(id, value): any[] {
-    if (!this.checkIfDataExists(id)) {
+    // We cannot concatenate an undefined object
+    if (!this.checkIfDataExists(id) || !this.getItemValue(id)) {
       this.setItemValue(id, value);
       return [];
     } else {
@@ -35,7 +36,8 @@ export class DataService {
 
   // Merge object data to existing dataService id
   mergeItemValue(id, value, attribute = null): any {
-    if (!this.checkIfDataExists(id)) {
+    // We cannot merge to an undefined object
+    if (!this.checkIfDataExists(id) || !this.getItemValue(id)) {
       this.setItemValue(id, value);
       return null;
     } else {

--- a/src/app/services/reservation.service.spec.ts
+++ b/src/app/services/reservation.service.spec.ts
@@ -110,6 +110,7 @@ describe('ReservationService', () => {
       overbooked: 0,
       modifier: 8,
       style: 'success',
+      checkInCount: 0,
     };
     service.setCapacityBar(MockData.mockReservationObj_1, 'AM');
     expect(setDataSpy).toHaveBeenCalledOnceWith(

--- a/src/app/services/reservation.service.ts
+++ b/src/app/services/reservation.service.ts
@@ -138,6 +138,14 @@ export class ReservationService {
       : 0;
     capBarObj.style = this.calculateProgressBarColour(capBarObj.capPercent);
 
+    // get current checked-in count, if any
+    let currentCapBar = this.dataService.getItemValue(Constants.dataIds.CURRENT_CAPACITY_BAR_OBJECT);
+    if (currentCapBar?.checkInCount) {
+      capBarObj['checkInCount'] = currentCapBar.checkInCount;
+    } else {
+      capBarObj['checkInCount'] = 0;
+    }
+
     this.dataService.setItemValue(
       Constants.dataIds.CURRENT_CAPACITY_BAR_OBJECT,
       capBarObj

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -6,6 +6,7 @@ export class Constants {
     FACILITIES_LIST: 'facilitiesList',
     CURRENT_FACILITY_KEY: 'currentFacilityKey',
     PASSES_LIST: 'passesList',
+    FILTERED_PASSES_LIST: 'filteredPassesList',
     PASS_SEARCH_PARAMS: 'passSearchParams',
     PASS_LAST_EVALUATED_KEY: 'passLastEvaluatedKey',
     CANCELLED_PASS: 'cancelledPass',

--- a/src/app/shared/utils/mock-data.ts
+++ b/src/app/shared/utils/mock-data.ts
@@ -166,6 +166,8 @@ export class MockData {
     registrationNumber: '1234567890',
     shortPassDate: '2022-12-18',
     type: 'PM',
+    checkedIn: true,
+    checkedInTime: '2022-12-18T19:00:00.000Z'
   };
 
   public static readonly mockPass_2 = {


### PR DESCRIPTION
### Jira Ticket:
BRS-1089/BRS-1017

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1089
https://bcparksdigital.atlassian.net/browse/BRS-1017

### Description:
This change introduces new visual updates to the Pass Management section of the site, now located on its own route. The updates include:

- new accordion-style table display for passes returned by the pass search filters
- responsive table columns that collapse into the accordion dropdown based on importance
- various pass data elements added to the pass results
- Filter returned passes based on `checkedIn` status

A couple of points:

1.  The new accordions are complex and, on slower browsers, may slow down pages with many results ( >1000, for example, if you don't filter by a date).
2. The responsive design does not include html table elements (`tr`, `td`, `tbody`, etc).
3.  The `checkedIn` filters are applied after the api returns a list of passes. Ideally this would be handled in the API, but based on the designs it appears that this filter is intended to be used after the other filters have been applied and a pass list is returned.
4. The global `dataService` was slightly modified to improve the functionality of the lesser-used `appendItemValue` and `mergeItemValue`: effectively, if an item in the data store was defined but had no value (`null` or `undefined`), then that item/value could not be concatenated or merged with.
5. On loading the pass list page with query params in the URL, the page is supposed to autosearch if the correct params are available. A race condition was fixed where the params would fail to search because the autofetched parks and facilities had not been loaded in yet. 