### PR TITLE
BRS-1166: Avoiding filter changes when data in backend does not change.

### DIFF
--- a/src/app/services/auto-fetch.service.ts
+++ b/src/app/services/auto-fetch.service.ts
@@ -68,11 +68,34 @@ export class AutoFetchService {
     forkJoin(observables)
       .pipe(first())
       .subscribe((res) => {
+
+        const existingParkAndFacilityList = this.dataService.getItemValue(Constants.dataIds.PARK_AND_FACILITY_LIST);
+        if (existingParkAndFacilityList) {
+          // convert existingParkAndFacilityList to array in order to check if they are the same.
+          const result = Object.entries(existingParkAndFacilityList).map(([k, v]) => ({ [k]: v }));
+
+          if (this.ignoreOrderCompare(result, res)) {
+            // The park and facility list is the same.  Don't re-set it, it is a noop.
+            return;
+          }
+        }
+
         Object.assign(parksObj, ...res);
         this.dataService.setItemValue(
           Constants.dataIds.PARK_AND_FACILITY_LIST,
           parksObj
         );
       });
+  }
+
+  ignoreOrderCompare(a, b) {
+    if (a.length !== b.length) return false;
+    const elements = new Set([...a, ...b]);
+    for (const x of elements) {
+      const count1 = a.filter(e => e === x).length;
+      const count2 = b.filter(e => e === x).length;
+      if (count1 !== count2) return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-1166

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1166

### Description:
This solves an issue where the filters are getting force updated from the auto-fetcher service even if there were no changes to park and facility list data.  This will deal with 99% of the cases where there are no changes.  When there are changes, it will reset the UI but that is to be expected because we won't want the user to be able to send queries to say, non-existing facilities anymore, therefore the dropdowns should change.