### PR TITLE
BRS-267: Adding fields to supply safety video link through edit park

### DIFF
--- a/src/app/parks-management/park-details/park-details.component.html
+++ b/src/app/parks-management/park-details/park-details.component.html
@@ -60,6 +60,15 @@
       </div>
     </div>
     <div class="row">
+      <div class="col-md-6">
+        <label><strong>Video Link:</strong></label>
+        <br />
+        <p><a *ngIf="park?.videoLink" href="{{ park?.videoLink }}">{{
+          park?.videoLink
+        }}</a></p>
+      </div>
+    </div>
+    <div class="row">
       <div class="col-12">
         <label><strong>Description:</strong></label>
         <p [innerHTML]="park?.description"></p>

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.html
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.html
@@ -102,6 +102,22 @@
           </button>
         </div>
       </div>
+      <div class="row align-items-end">
+        <div class="col-10">
+          <app-text-input
+            [control]="fields?.parkVideoLink"
+            [label]="'Link to Video'"
+            [type]="'text'"
+            [id]="'parkVideoLink'"
+          >
+          </app-text-input>
+        </div>
+        <div class="col">
+          <button class="btn btn-primary mb-3" (click)="testVideoLink($event)">
+            Test Link
+          </button>
+        </div>
+      </div>
     </section>
 
     <section class="form-section">

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.spec.ts
@@ -27,6 +27,7 @@ describe('ParkEditFormComponent', () => {
       orcs: mockPark.orcs,
       bcParksLink: mockPark.bcParksLink,
       mapLink: mockPark.bcParksLink,
+      videoLink: null,
       status: mockPark.status,
       capacity: mockPark.capacity,
     },

--- a/src/app/parks-management/park-edit-form/park-edit-form.component.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.ts
@@ -73,6 +73,7 @@ export class ParkEditFormComponent extends BaseFormComponent {
         Validators.required
       ),
       parkMapLink: new UntypedFormControl(this.data.mapLink),
+      parkVideoLink: new UntypedFormControl(this.data.videoLink),
       parkDescription: new UntypedFormControl(this.data.description),
     });
     super.updateForm();
@@ -105,6 +106,7 @@ export class ParkEditFormComponent extends BaseFormComponent {
         orcs: results.parkOrcs,
         bcParksLink: results.parkSiteLink,
         mapLink: results.parkMapLink,
+        videoLink: results.parkVideoLink,
         status: results.parkStatus === true ? 'open' : 'closed',
         capacity: results.parkCapacity,
       },
@@ -173,6 +175,8 @@ export class ParkEditFormComponent extends BaseFormComponent {
     message +=
       `</br></br><strong>Link to map:</strong></br>` + parkObj.park?.mapLink;
     message +=
+    `</br></br><strong>Link to video:</strong></br>` + parkObj.park?.videoLink;
+    message +=
       `</br></br><strong>Description:</strong></br>` + parkObj.description;
     return message;
   }
@@ -185,6 +189,11 @@ export class ParkEditFormComponent extends BaseFormComponent {
   testMapLink(event) {
     event.preventDefault();
     window.open(this.fields.parkMapLink.value);
+  }
+
+  testVideoLink(event) {
+    event.preventDefault();
+    window.open(this.fields.parkVideoLink.value);
   }
 
   navigateBack() {


### PR DESCRIPTION
Jira Ticket:
BRS-267 - Add safety video to Park Information
Links to DUP-PUBLIC PR: https://github.com/bcgov/parks-reso-public/pull/271
Links to DUP-API PR: https://github.com/bcgov/parks-reso-api/pull/298

Jira Ticket URL:
https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=39881272

Description:
Add section to edit form to include video link for park.
Summary page now includes the Link for park preview.
Logic included to add video link to the PUT request when editing a park. 