### PR TITLE
BRS-311: Disable edit park name through DUP Admin

### DIFF
--- a/src/app/parks-management/park-edit-form/park-edit-form.component.ts
+++ b/src/app/parks-management/park-edit-form/park-edit-form.component.ts
@@ -78,6 +78,7 @@ export class ParkEditFormComponent extends BaseFormComponent {
     });
     super.updateForm();
     super.addDisabledRule(this.fields.parkOrcs);
+    super.addDisabledRule(this.fields.parkName);
   }
 
   async onSubmit() {


### PR DESCRIPTION
### Jira Ticket:
BRS-311 

Links to [DUP - API - #312 ](https://github.com/bcgov/parks-reso-api/pull/312)

### Jira Ticket URL:
[DUP Admin -> The "Park name" should be read only in edit mode.#311](https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=42084240)

### Description:
Disable the Park Name field on edit park form. 