### PR TITLE
308: DUP Admin - empty links in menu

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ const routes: Routes = [
     data: {
       label: 'Home',
       breadcrumb: 'Home',
+      sidebar: true,
       icon: 'bi-house-fill',
     },
   },
@@ -27,6 +28,7 @@ const routes: Routes = [
     data: {
       label: 'Parks Management',
       breadcrumb: 'Parks',
+      sidebar: true,
       icon: 'bi-tree-fill',
     },
     loadChildren: () =>
@@ -41,6 +43,7 @@ const routes: Routes = [
     data: {
       label: 'Pass Management',
       breadcrumb: 'Pass Management',
+      sidebar: true,
       icon: 'bi-pass-fill',
     },
     loadChildren: () =>
@@ -56,6 +59,7 @@ const routes: Routes = [
     data: {
       label: 'Metrics',
       breadcrumb: 'Metrics',
+      sidebar: true,
       icon: 'bi-bar-chart-fill',
     },
     loadChildren: () =>

--- a/src/app/shared/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.spec.ts
@@ -17,8 +17,8 @@ describe('SidebarComponent', () => {
   let router;
 
   let mockRoutes = [
-    { path: 'mock1', component: HomeComponent, data: { icon: 'bi-circle' } },
-    { path: 'mock2', component: HomeComponent, data: { icon: 'bi-circle' } },
+    { path: 'mock1', component: HomeComponent, data: { icon: 'bi-circle', sidebar: true } },
+    { path: 'mock2', component: HomeComponent, data: { icon: 'bi-circle', sidebar: false } },
   ];
 
   let mockSideBarService = {
@@ -48,7 +48,7 @@ describe('SidebarComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    expect(component.routes.length).toEqual(2);
+    expect(component.routes.length).toEqual(1);
     expect(component.hide).toBeFalse();
   });
 

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -25,7 +25,14 @@ export class SidebarComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       sideBarService.routes.subscribe((routes) => {
-        this.routes = routes;
+        // Peel out the non-active routes.
+        let displayedRoutes = [];
+        for(let r of routes) {
+          if (r.data.sidebar === true) {
+            displayedRoutes.push(r);
+          }
+        }
+        this.routes = displayedRoutes;
       })
     );
 


### PR DESCRIPTION
Added a `sidebar: <true/false>` in order to allow the sidebar to reference whether or not to show the route.  Some routes were not useful to be in the sidebar.