### PR TITLE
PDR-309 adding status and passes required to metrics csv

### DIFF
--- a/src/app/services/metrics.service.ts
+++ b/src/app/services/metrics.service.ts
@@ -115,13 +115,12 @@ export class MetricsService {
       // This may have to change later.
       const parkName = this.dataService.getItemValue(Constants.dataIds.PARK_AND_FACILITY_LIST)[park].name;
       const dateInterval = this.utils.createShortDateInterval(dateRange[0], dateRange[1]);
-      let content = [['Park', 'Facility', 'Date', 'Status', 'AM base capacity', 'AM capacity modifier', 'AM total passes', 'AM booked passes', 'AM checked-in', 'AM cancellations', 'PM base capacity', 'PM capacity modifier', 'PM total passes', 'PM booked passes', 'PM checked-in', 'PM cancellations', 'All-Day base capacity', 'All-Day capacity modifier', 'All-Day total passes', 'All-Day booked passes', 'All-day checked-in', 'All-Day cancellations']];
+      let content = [['Park', 'Facility', 'Date', 'Status', 'Passes required', 'AM base capacity', 'AM capacity modifier', 'AM total passes', 'AM booked passes', 'AM checked-in', 'AM cancellations', 'PM base capacity', 'PM capacity modifier', 'PM total passes', 'PM booked passes', 'PM checked-in', 'PM cancellations', 'All-Day base capacity', 'All-Day capacity modifier', 'All-Day total passes', 'All-Day booked passes', 'All-day checked-in', 'All-Day cancellations']];
       for (const date of dateInterval) {
         let metric = metricsList.find((item) => item.sk === date);
-        console.log('metric:', metric);
         content.push([parkName, facility, date,
-          'N/A', // TODO: update metrics to include open/closed status
-          // AM
+          metric?.status ?? 'N/A',
+          metric?.passesRequired ?? 'N/A',
           metric?.capacities?.AM?.baseCapacity ?? 'N/A',
           metric?.capacities?.AM?.capacityModifier ?? 'N/A',
           isNaN(metric?.capacities?.AM?.baseCapacity + metric?.capacities?.AM?.capacityModifier) ?


### PR DESCRIPTION
With [#341](https://github.com/bcgov/parks-reso-api/pull/341), completes #309.

Adds the new fields of `status` and `passesRequired` to the metrics csv report. Note: [#341](https://github.com/bcgov/parks-reso-api/pull/341) must first be merged.