### PR TITLE
BRS-405: Add ability to edit link in WYSIWYG

### DIFF
--- a/src/app/shared/components/ds-forms/wysiwyg-input/wysiwyg-input.component.html
+++ b/src/app/shared/components/ds-forms/wysiwyg-input/wysiwyg-input.component.html
@@ -16,6 +16,7 @@
       suffix: '.min',
       height: 300,
       menubar: false,
+      plugins: 'link',
       toolbar:
         'undo redo | formatselect | bold italic backcolor | \
     alignleft aligncenter alignright alignjustify | link | \


### PR DESCRIPTION
Ticket: [405](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=67019537&issue=bcgov%7Cparks-reso-public%7C405)
Notes: Added the link feature to the WYSIWYG text box. This will allow DUP admins to edit links and select how they will be opened from within the admin portal. 

![image](https://github.com/user-attachments/assets/e3156b00-07a8-464c-bc53-98e67258a631)
![image](https://github.com/user-attachments/assets/b4023584-7967-42fa-a662-fa44acb1e1f4)

