### PR TITLE
feat(cf): forward Auth + CORS on /api/*, bump TLS min

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -144,7 +144,7 @@ Resources:
           AcmCertificateArn:
             Ref: DomainCertificateArn
           SslSupportMethod: sni-only
-          MinimumProtocolVersion: TLSv1
+          MinimumProtocolVersion: TLSv1.2_2021
         Comment:
           Fn::Sub: CloudFront distribution for ${AWS::StackName}
         DefaultRootObject:
@@ -195,12 +195,10 @@ Resources:
           - POST
           - PATCH
           - DELETE
-          CachePolicyId:
-            Ref: CloudFrontAPICachePolicy
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
           TargetOriginId: !Sub ${ApiGatewayId}
           ViewerProtocolPolicy: redirect-to-https
-          ResponseHeadersPolicyId:
-            Ref: CloudFrontResponseHeadersPolicy
         - PathPattern:
             Fn::Sub: ${BaseHref}*
           Compress: true


### PR DESCRIPTION
Switches the CF `/api/*` behavior to managed `CachingDisabled` + `AllViewerExceptHostHeader` so Authorization and CORS preflight reach API Gateway. Raises viewer TLS minimum to 1.2_2021.